### PR TITLE
Make it possible to add generic config blocks in sites and configs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,30 +17,20 @@ nginx_sites:
      - listen 8080
      - server_name localhost
      - root "/tmp/site1"
-    location1: 
-       name: /
-       vars: 
-          - try_files $uri $uri/ /index.html
-    location2:
-       name: /images/
-       vars:
-          - try_files $uri $uri/ /index.html
+     - location / { try_files $uri $uri/ /index.html; }
+     - location /images/ { try_files $uri $uri/ /index.html; }
  - server:
     file_name: bar
     vars:
      - listen 9090
      - server_name ansible
      - root "/tmp/site2"
-    location1: 
-       name: /
-       vars: 
-          - try_files $uri $uri/ /index.html
-    location2:
-       name: /images/
-       vars:
-          - try_files $uri $uri/ /index.html
-          - allow 127.0.0.1
-          - deny all
+     - location / { try_files $uri $uri/ /index.html; }
+     - location /images/ {
+         try_files $uri $uri/ /index.html;
+         allow 127.0.0.1;
+         deny all;
+       }
 
 nginx_configs:
   - config:
@@ -48,3 +38,14 @@ nginx_configs:
      vars:
       - proxy_set_header X-Real-IP  $remote_addr
       - proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
+  - config:
+     file_name: upstream
+     vars:
+      - upstream foo { server 127.0.0.1:8080 weight=10; }
+  - config:
+     file_name: geo
+     vars:
+      - geo $local {
+          default 0;
+          127.0.0.1 1;
+        }

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -1,4 +1,5 @@
 #{{ ansible_managed }}
+
 {% for v in item.config.vars %}
-{{ v }};
-{% endfor %} 
+   {{ v.replace(";",";\n      ").replace("{","{\n      ").replace("}","\n   }\n") }}{% if v.find('{') == -1%} ;{% endif %} 
+{% endfor %}

--- a/templates/site.j2
+++ b/templates/site.j2
@@ -2,15 +2,7 @@
 server {
 
 {% for v in item.server.vars %}
-   {{ v }};
-{% endfor %} 
+   {{ v.replace(";",";\n      ").replace("{","{\n      ").replace("}","\n   }\n") }}{% if v.find('{') == -1%} ;{% endif %} 
+{% endfor %}
 
-{% for k,v in item.server.iteritems() if k.find('location') != -1 %}
-  location {{ v.name }} {
-{% for y in v.vars %}
-      {{ y }};
-{% endfor %}
-  }
-{% endfor %}
 }
-


### PR DESCRIPTION
Sometimes you have to deal with configuration blocks like:

http {
...
  upstream default {
    server 127.0.0.1:8080 weight=10;
    server 127.0.0.1:9090 weight=20;
    ...
  }
...
  server {
    ...
    if ( condition ) {
      ...
    }
    ...
    location / {
      ...
    }
    ...
  }
}

This commits make it possible to add such blocks to the /etc/nginx/conf.d/_.conf files generated by this role and to the /etc/nginx/sites-enabled/_.conf
