### PR TITLE
Disable the default site

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,6 +60,13 @@
    - reload nginx
   tags: [configuration,nginx]
 
+- name: Disable the default site
+  file: path=/etc/nginx/sites-enabled/default state=absent
+  when: nginx_sites.keys() != []
+  notify:
+   - reload nginx
+  tags: [configuration,nginx]
+
 - name: Create the configurations for independante config file
   template: src=config.conf.j2 dest=/etc/nginx/conf.d/{{ item }}.conf
   with_items: nginx_configs.keys()


### PR DESCRIPTION
This disables the nginx welcome page so that a different default_server can be set from nginx_sites. The default site is only disabled when another site has been configured.
