### PR TITLE
Make repository selection configurable on RedHat

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+yum_epel_repo: epel
+yum_base_repo: base
+
 nginx_user: "{% if ansible_os_family == 'RedHat' %}nginx{% elif ansible_os_family == 'Debian' %}www-data{% endif %}"
 nginx_group: "{{nginx_user}}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,18 +5,18 @@
   when: ansible_os_family == "RedHat"
   tags: [packages,nginx]
 
-- name: Copy the epel packages 
-  copy: src=epel.repo dest=/etc/yum.repos.d/epel_ansible.repo
+- name: Copy the epel packages
+  template: src=epel.repo.j2 dest=/etc/yum.repos.d/epel_ansible.repo
   when: ansible_os_family == "RedHat"
   tags: [packages,nginx]
 
-- name: Install the nginx packages 
-  yum: name={{ item }} state=present
+- name: Install the nginx packages
+  yum: name={{ item }} state=present disablerepo='*' enablerepo={{ yum_epel_repo }},{{ yum_base_repo }}
   with_items: redhat_pkg
   when: ansible_os_family == "RedHat"
   tags: [packages,nginx]
 
-- name: Install the nginx packages 
+- name: Install the nginx packages
   apt: name={{ item }} state=present update_cache=yes
   with_items: ubuntu_pkg
   environment: env
@@ -35,9 +35,9 @@
   file: path={{ nginx_log_dir }} state=directory owner={{nginx_user}} group={{nginx_group}} mode=0755
   tags: [configuration,nginx]
 
-- name: Copy the nginx configuration file 
+- name: Copy the nginx configuration file
   template: src=nginx.conf.j2 dest=/etc/nginx/nginx.conf
-  notify: 
+  notify:
    - restart nginx
   tags: [configuration,nginx]
 
@@ -49,14 +49,14 @@
 - name: Create the configurations for sites
   template: src=site.conf.j2 dest=/etc/nginx/sites-available/{{ item }}.conf
   with_items: nginx_sites.keys()
-  notify: 
+  notify:
    - reload nginx
   tags: [configuration,nginx]
 
 - name: Create links for sites-enabled
   file: state=link src=/etc/nginx/sites-available/{{ item }}.conf dest=/etc/nginx/sites-enabled/{{ item }}.conf
   with_items: nginx_sites.keys()
-  notify: 
+  notify:
    - reload nginx
   tags: [configuration,nginx]
 
@@ -67,10 +67,10 @@
    - reload nginx
   tags: [configuration,nginx]
 
-- name: Create the configurations for independante config file
+- name: Create the configurations for independent config file
   template: src=config.conf.j2 dest=/etc/nginx/conf.d/{{ item }}.conf
   with_items: nginx_configs.keys()
-  notify: 
+  notify:
    - reload nginx
   tags: [configuration,nginx]
 

--- a/templates/epel.repo.j2
+++ b/templates/epel.repo.j2
@@ -1,4 +1,5 @@
-[epel]
+#{{ ansible_managed }}
+[{{ yum_epel_repo }}]
 name=Extra Packages for Enterprise Linux 6 - $basearch
 baseurl=http://download.fedoraproject.org/pub/epel/6/$basearch
 #mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch
@@ -7,7 +8,7 @@ enabled=1
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
 
-[epel-debuginfo]
+[{{ yum_epel_repo }}-debuginfo]
 name=Extra Packages for Enterprise Linux 6 - $basearch - Debug
 #baseurl=http://download.fedoraproject.org/pub/epel/6/$basearch/debug
 mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-debug-6&arch=$basearch
@@ -16,7 +17,7 @@ enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
 gpgcheck=1
 
-[epel-source]
+[{{ yum_epel_repo }}-source]
 name=Extra Packages for Enterprise Linux 6 - $basearch - Source
 #baseurl=http://download.fedoraproject.org/pub/epel/6/SRPMS
 mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-source-6&arch=$basearch


### PR DESCRIPTION
Our centos boxes are configured with multiple repositories
that contain the nginx package, and this role was previously
picking the wrong one.

This change aggressively prunes the enabled repo list to
minimize such potential conflicts, and adds configurability
just in case there's a name mismatch.
