### PR TITLE
Setting auto mode by default for worker_processes parameter

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -1,7 +1,7 @@
 #{{ ansible_managed }}
 user              {{ nginx_user }};
 
-worker_processes  {{ nginx_worker_processes }};
+worker_processes  {{ nginx_worker_processes | default('auto') }};
 pid        /var/run/nginx.pid;
 worker_rlimit_nofile {{ nginx_worker_rlimit_nofile }};
 


### PR DESCRIPTION
Hi,

It would be nice to set the auto mode if nothing is set as described in the official documentation (http://nginx.org/en/docs/ngx_core_module.html#worker_processes). If you don't want to use auto because it requires a certain version, you may use this instead:

```
worker_processes {{ nginx_workers_processes | default(ansible_processor_cores) }};
```

What do you think about it ?
