### PR TITLE
Add libarian-ansible version support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,4 +25,5 @@ galaxy_info:
   categories:
    - web
 dependencies: []
+version: 1.3.3
 


### PR DESCRIPTION
@jdauphant can this be added and maintained going forward?

Adding [librarian-ansible](https://github.com/bcoe/librarian-ansible)
support to provide bundler like functionality for ansible playbooks.

Version support is handled by specifying version numbers to your
meta/main.yml file e.g.:

```code
---
galaxy_info:
...
dependencies: []
version: 2.0.0
---
```