### PR TITLE
Move the binary and service names to the default variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,7 @@ keep_only_specified: False
 
 nginx_installation_type: "packages"
 nginx_binary_name: "nginx"
-nginx_service_name: "nginx"
+nginx_service_name: "{{nginx_binary_name}}"
 nginx_conf_dir: "/etc/nginx"
 
 nginx_user: "{% if ansible_os_family == 'RedHat' %}nginx{% elif ansible_os_family == 'Debian' %}www-data{% endif %}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,8 @@ nginx_official_repo: False
 keep_only_specified: False
 
 nginx_installation_type: "packages"
+nginx_binary_name: "nginx"
+nginx_service_name: "nginx"
 nginx_conf_dir: "/etc/nginx"
 
 nginx_user: "{% if ansible_os_family == 'RedHat' %}nginx{% elif ansible_os_family == 'Debian' %}www-data{% endif %}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: restart nginx
-  service: name=nginx state=restarted 
+  service: name={{ nginx_service_name }} state=restarted
   when: nginx_installation_type in nginx_installation_types_using_service and nginx_daemon_mode == "on"
 
 - name: reload nginx
-  service: name=nginx state=reloaded
+  service: name={{ nginx_service_name }} state=reloaded
   when: nginx_installation_type in nginx_installation_types_using_service and nginx_daemon_mode == "on"

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -45,7 +45,7 @@
   tags: [configuration,nginx]
 
 - name: Check nginx syntax of configuration files
-  shell: nginx -t
+  shell: "{{ nginx_binary_name }} -t"
   register: result
   changed_when: "result.rc != 0"
   always_run: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,6 @@
 - include: configuration.yml
 
 - name: Start the nginx service
-  service: name=nginx state=started enabled=yes
+  service: name={{ nginx_service_name }} state=started enabled=yes
   when: nginx_installation_type in nginx_installation_types_using_service and nginx_daemon_mode == "on"
   tags: [service,nginx]


### PR DESCRIPTION
Move the binary and service names to the default variables, so they can be overwritten for custom Nginx builds.