### PR TITLE
Make use of nginx_conf_dir for includes in nginx.conf.j2

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -12,14 +12,14 @@ events {
 
 http {
 
-        include /etc/nginx/mime.types;
+        include {{ nginx_conf_dir }}/mime.types;
         default_type application/octet-stream;
 {% for v in nginx_http_params %}
         {{ v }};
 {% endfor %}
 
-        include /etc/nginx/conf.d/*.conf;
-        include /etc/nginx/sites-enabled/*;
+        include {{ nginx_conf_dir }}/conf.d/*.conf;
+        include {{ nginx_conf_dir }}/sites-enabled/*;
 }
 
 {% if nginx_daemon_mode == "off" %}


### PR DESCRIPTION
If your Nginx config dir is located not in /etc/nginx, the playbook will fail, because of the hardcoded path in the nginx.conf template.
This commit resolves this issue.