### PR TITLE
Make the pid directive configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,8 @@ nginx_conf_dir: "/etc/nginx"
 nginx_user: "{% if ansible_os_family == 'RedHat' %}nginx{% elif ansible_os_family == 'Debian' %}www-data{% endif %}"
 nginx_group: "{{nginx_user}}"
 
+nginx_pid_file: '/var/run/{{nginx_service_name}}.pid'
+
 nginx_worker_processes: "{{ ansible_processor_vcpus }}"
 nginx_max_clients: 512
 nginx_worker_rlimit_nofile: 1024

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -2,7 +2,11 @@
 user              {{ nginx_user }};
 
 worker_processes  {{ nginx_worker_processes }};
-pid        /var/run/nginx.pid;
+
+{% if nginx_pid_file %}
+pid        {{ nginx_pid_file }};
+{% endif %}
+
 worker_rlimit_nofile {{ nginx_worker_rlimit_nofile }};
 
 events {


### PR DESCRIPTION
Pid is now configurable, because otherwise it can lead to problems with the init script on custom builds.