### PR TITLE
Implement nginx_events_params

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,15 @@ The variables that can be passed to this role and a brief description about
 them are as follows.
 
 ```yaml
-# The max clients allowed
-nginx_max_clients: 512 
-
 # The user to run nginx
 nginx_user: "www-data"
+
+# A list of directives for the events section.
+nginx_events_params:
+ - worker_connections 512
+ - debug_connection 127.0.0.1
+ - use epoll
+ - multi_accept on
 
 # A list of hashs that define the servers for nginx,
 # as with http parameters. Any valid server parameters

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,9 +24,11 @@ nginx_group: "{{nginx_user}}"
 nginx_pid_file: '/var/run/{{nginx_service_name}}.pid'
 
 nginx_worker_processes: "{{ ansible_processor_vcpus }}"
-nginx_max_clients: 512
 nginx_worker_rlimit_nofile: 1024
 nginx_log_dir: "/var/log/nginx"
+
+nginx_events_params:
+  - worker_connections {% if nginx_max_clients %}{{nginx_max_clients}}{% else %}512{% endif %}
 
 nginx_http_params:
   - sendfile "on"

--- a/example-vars.yml
+++ b/example-vars.yml
@@ -1,7 +1,4 @@
 ---
-# The max clients allowed
-nginx_max_clients: 512 
-
 # The user to run nginx
 nginx_user: "www-data"
 
@@ -15,6 +12,10 @@ nginx_hhvm: |
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         include       fastcgi_params;
       }
+
+# A list of directives for the events section.
+nginx_events_params:
+  - worker_connections 512
 
 # A list of hashs that define the servers for nginx,
 # as with http parameters. Any valid server parameters

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -10,7 +10,9 @@ pid        {{ nginx_pid_file }};
 worker_rlimit_nofile {{ nginx_worker_rlimit_nofile }};
 
 events {
-    worker_connections  {{ nginx_max_clients }};
+{% for v in nginx_events_params %}
+        {{ v }};
+{% endfor %}
 }
 
 


### PR DESCRIPTION
Implement nginx_events_params and move worker_connections to it.

This allows to implement additional directives in the events module.