### PR TITLE
Prefix env variable

### DIFF
--- a/tasks/installation.packages.yml
+++ b/tasks/installation.packages.yml
@@ -24,6 +24,6 @@
 - name: Install the nginx packages
   apt: name={{ item }} state=present
   with_items: nginx_ubuntu_pkg
-  environment: env
+  environment: nginx_env
   when: ansible_os_family == "Debian"
   tags: [packages,nginx]

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 
-env:
+nginx_env:
  RUNLEVEL: 1
 
 nginx_installation_types_using_service: ["packages"]


### PR DESCRIPTION
Prefix env variable to avoid collision with a too generic "env" variable name (often used as tag on AWS)