### PR TITLE
Adding support for openSUSE (User should still define a repo)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,9 @@ nginx_ubuntu_pkg:
 nginx_freebsd_pkg:
   - nginx
 
+nginx_suse_pkg:
+  - nginx
+
 yum_epel_repo: epel
 yum_base_repo: base
 
@@ -21,7 +24,7 @@ nginx_binary_name: "nginx"
 nginx_service_name: "{{nginx_binary_name}}"
 nginx_conf_dir: "{% if ansible_os_family == 'FreeBSD' %}/usr/local/etc/nginx{% else %}/etc/nginx{% endif %}"
 
-nginx_user: "{% if ansible_os_family == 'RedHat' %}nginx{% elif ansible_os_family == 'Debian' %}www-data{% elif ansible_os_family == 'FreeBSD' %}www{% endif %}"
+nginx_user: "{% if ansible_os_family == 'RedHat' or ansible_os_family == 'Suse' %}nginx{% elif ansible_os_family == 'Debian' %}www-data{% elif ansible_os_family == 'FreeBSD' %}www{% endif %}"
 nginx_group: "{{nginx_user}}"
 
 nginx_pid_file: '/var/run/{{nginx_service_name}}.pid'

--- a/tasks/installation.packages.yml
+++ b/tasks/installation.packages.yml
@@ -35,3 +35,8 @@
   when: ansible_os_family == "FreeBSD"
   tags: [packages,nginx]
 
+- name: Install the nginx packages
+  zypper: name={{ item }} state=present 
+  with_items: nginx_suse_pkg
+  when: ansible_os_family == "Suse"
+  tags: [packages,nginx]


### PR DESCRIPTION
This change adds support for openSUSE (13.1 and 13.2 tested) so it ensures the package is installed and the correct user is set.  nginx is not in main openSUSE repository for 13.x but it does appear that it will be / is for tumbleweed and Leap 42.  It is therefore required that a repository for nginx is configured or the packaged is already installed for this module to work when using 13.x.  Not tested on SLES.