### PR TITLE
Fix meta typo

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,8 +15,8 @@ galaxy_info:
       - 18
       - 19
       - 20
-  - name: opensuse
-    versions:
+   - name: opensuse
+     versions:
       - 13.1
       - 13.2
    - name: Ubuntu


### PR DESCRIPTION
Fixed indentation typo in meta/main.yml.  Module will not parse otherwise e.g:

```The error may actually appear before this position: line 18, column 3```
