### PR TITLE
Allow the default site to be removed with hash merge behavior

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -25,14 +25,14 @@
 
 - name: Create the configurations for sites
   template: src=site.conf.j2 dest={{nginx_conf_dir}}/sites-available/{{ item }}.conf
-  with_items: nginx_sites.keys()
+  with_items: nginx_sites.keys() | difference(nginx_remove_sites)
   notify:
    - restart nginx
   tags: [configuration,nginx]
 
 - name: Create links for sites-enabled
   file: state=link src={{nginx_conf_dir}}/sites-available/{{ item }}.conf dest={{nginx_conf_dir}}/sites-enabled/{{ item }}.conf
-  with_items: nginx_sites.keys()
+  with_items: nginx_sites.keys() | difference(nginx_remove_sites)
   notify:
    - reload nginx
   tags: [configuration,nginx]


### PR DESCRIPTION
Fixes #75. 

If a user is using the hash merge behavior they can remove the default site by adding it to `nginx_remove_sites` and it will not be re-added after having been removed.