### PR TITLE
Using the full variable syntax for environment variables

### DIFF
--- a/tasks/installation.packages.yml
+++ b/tasks/installation.packages.yml
@@ -24,14 +24,14 @@
 - name: Install the nginx packages
   apt: name={{ item }} state=present
   with_items: nginx_ubuntu_pkg
-  environment: nginx_env
+  environment: "{{ nginx_env }}"
   when: ansible_os_family == "Debian"
   tags: [packages,nginx]
 
 - name: Install the nginx packages
   pkgng: name={{ item }} state=present
   with_items: nginx_freebsd_pkg
-  environment: nginx_env
+  environment: "{{ nginx_env }}"
   when: ansible_os_family == "FreeBSD"
   tags: [packages,nginx]
 


### PR DESCRIPTION
Addressing this warning: [DEPRECATION WARNING]: Using bare variables for environment is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{foo}}').