### PR TITLE
Includes files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,6 +57,9 @@ nginx_remove_sites: []
 nginx_configs: {}
 nginx_remove_configs: []
 
+nginx_include_dir: includes
+nginx_includes: {}
+
 nginx_auth_basic_files: {}
 nginx_remove_auth_basic_files: []
 

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -43,3 +43,13 @@
   notify:
    - reload nginx
   tags: [configuration,nginx]
+
+- name: Create the include directory
+  file: path={{nginx_conf_dir}}/{{nginx_include_dir}} state=directory owner=root group={{nginx_group}} mode=0755
+  when: nginx_includes|length()>0
+  tags: [configuration,nginx]
+
+- name: Create the configurations for include file
+  template: src=includes.conf.j2 dest={{nginx_conf_dir}}/{{nginx_include_dir}}/{{ item }}.conf
+  with_items: nginx_includes.keys()
+  tags: [configuration,nginx]

--- a/templates/includes.conf.j2
+++ b/templates/includes.conf.j2
@@ -1,0 +1,9 @@
+#{{ ansible_managed }}
+
+{% for v in nginx_includes[item] %}
+{% if v.find('\n') != -1 %}
+{{v}}
+{% else %}
+{% if v != "" %}{{ v.replace(";",";\n   ").replace(" {"," {\n    ").replace(" }"," \n}\n") }}{% if v.find('{') == -1%};
+{% endif %}{% endif %}{% endif %}
+{% endfor %}


### PR DESCRIPTION
The purpose of this PR is to add the ability to create configuration file which can be include in server block configuration.

Let create variable: 
```
nginx_includes:
  expires:
    - location ~* \.(?:rss|atom)$ {
        expires 1h;
        add_header Cache-Control "public";
      }
    - location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc|swf)$ {
        expires 1M;
        access_log off;
        add_header Cache-Control "public";
      }
    - location ~* \.(?:css)$ {
        expires 1w;
        access_log off;
        add_header Cache-Control "public";
      }
    - location ~* \.(?:js)$ {
        expires 1M;
        access_log off;
        add_header Cache-Control "public";
      }
    - location ~* \.(?:ttf|ttc|otf|eot|woff|woff2)$ {
        expires 1M;
        access_log off;
        add_header Cache-Control "public";
      }
```

Note the nginx_include_dir is defined in default file (with "includes" value)

It will create a file /etc/nginx/includes/expires.conf wich can be included in all vhost with include directive.