### PR TITLE
fix task to reload nginx on sites configuration change instead of restart

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -27,7 +27,7 @@
   template: src=site.conf.j2 dest={{nginx_conf_dir}}/sites-available/{{ item }}.conf
   with_items: nginx_sites.keys() | difference(nginx_remove_sites)
   notify:
-   - restart nginx
+   - reload nginx
   tags: [configuration,nginx]
 
 - name: Create links for sites-enabled


### PR DESCRIPTION
Don't you think it would be better to reload nginx instead of restarting it whenever site configuration is added or changed?

Here is how this troubled me:

- I created a site configuration using this role
- Deployed the new site configuration
- Then I changed the path of my error log
- Deployed the changed site configuration

Expected behaviour:
If I would do this manually, I would make the changes and reload nginx.

Observed:
The role restarted nginx

Side note:
Also, don't you think it should be completely configurable what the user of the role wants to do i.e. reload or restart? The default behaviour can be as it is right now. But I feel the flexibility of being able to change that using variables will be very useful. Thoughts?