### PR TITLE
Dynamically defining  the filename (e.g. nginx-sites/{{my_variable}}.conf). 

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -31,7 +31,7 @@
   tags: [configuration,nginx]
 
 - name: Create links for sites-enabled
-  file: state=link src={{nginx_conf_dir}}/sites-available/{{ item }}.conf dest={{nginx_conf_dir}}/sites-enabled/{{ hostvars[inventory_hostname][item] | default(item) }}.conf
+  file: state=link src={{nginx_conf_dir}}/sites-available/{{ hostvars[inventory_hostname][item] | default(item) }}.conf dest={{nginx_conf_dir}}/sites-enabled/{{ hostvars[inventory_hostname][item] | default(item) }}.conf
   with_items: nginx_sites.keys() | difference(nginx_remove_sites)
   notify:
    - reload nginx

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -24,14 +24,14 @@
   tags: [configuration,nginx]
 
 - name: Create the configurations for sites
-  template: src=site.conf.j2 dest={{nginx_conf_dir}}/sites-available/{{ item }}.conf
+  template: src=site.conf.j2 dest={{nginx_conf_dir}}/sites-available/{{ hostvars[inventory_hostname][item] | default(item) }}.conf
   with_items: nginx_sites.keys() | difference(nginx_remove_sites)
   notify:
    - reload nginx
   tags: [configuration,nginx]
 
 - name: Create links for sites-enabled
-  file: state=link src={{nginx_conf_dir}}/sites-available/{{ item }}.conf dest={{nginx_conf_dir}}/sites-enabled/{{ item }}.conf
+  file: state=link src={{nginx_conf_dir}}/sites-available/{{ item }}.conf dest={{nginx_conf_dir}}/sites-enabled/{{ hostvars[inventory_hostname][item] | default(item) }}.conf
   with_items: nginx_sites.keys() | difference(nginx_remove_sites)
   notify:
    - reload nginx


### PR DESCRIPTION
This pull request tries first interpolate the key of the nginx-sites variable and if variable is not defined then uses key as filename(like now).

#### for example:
```
nginx_sites:
  # app_name is not defined
  app_name:
       ....
```
Creates /ets/nginx/sites-available/app_name.conf


```
app_name: my_app

nginx_sites:
  # app_name is defined
  app_name:
       ....
```
Creates /ets/nginx/sites-available/**my_app**.conf