### PR TITLE
Add support from FreeBSD port installation (compile source) rather then package

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,8 @@ nginx_ubuntu_pkg:
 nginx_freebsd_pkg:
   - nginx
 
+nginx_freebsd_port: "www/nginx"
+
 nginx_suse_pkg:
   - nginx
 

--- a/tasks/installation.source.yml
+++ b/tasks/installation.source.yml
@@ -1,0 +1,9 @@
+---
+- name: Install the nginx port
+  portinstall: name={{ item }} state=present
+  with_items: nginx_freebsd_port
+  environment: "{{ nginx_env }}"
+  when: ansible_os_family == "FreeBSD" 
+  tags:  [ source,nginx ]
+
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,8 @@
   when: nginx_official_repo == True
 - include: installation.packages.yml
   when: nginx_installation_type == "packages"
+- include: installation.source.yml
+  when: nginx_installation_type == "source"
 - include: remove-defaults.yml
   when: not keep_only_specified
 - include: remove-extras.yml


### PR DESCRIPTION
I'm not sure if this is the best way, so fell free to reject it, but I think this way we could use the instaltion.source.yml task to add other systems.

My main goal here however was FreeBSD and this is a 1st step, ideally a template for "make options" should be added so we can decide what to compile.

NOTES: this adds --> `nginx_freebsd_port` var with default "www/nginx" in case we want to use "www/nginx-devel" 
Also, and this is the part I'm not sure if its the best way...  but I've reused `nginx_installation_type` so in case he set it to `"source"` we would run the instaltion.source task...
