### PR TITLE
Don't fail when sites-enabled doesn't exist

### DIFF
--- a/tasks/remove-extras.yml
+++ b/tasks/remove-extras.yml
@@ -1,6 +1,6 @@
 ---
 - name: Find enabled sites
-  shell: ls -1 {{nginx_conf_dir}}/sites-enabled
+  shell: ls -1 {{nginx_conf_dir}}/sites-enabled || true
   register: enabled_sites
   changed_when: False
   tags: [configuration,nginx]


### PR DESCRIPTION
 (using nginx official packages)

We could also fix this using a stat + register, but wanted to keep changes minimal.