### PR TITLE
Fixed ansible 2.1.0 deprecations

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -20,26 +20,26 @@
 
 - name: Ensure auth_basic files created
   template: src=auth_basic.j2 dest={{nginx_conf_dir}}/auth_basic/{{ item }} owner=root group={{nginx_group}} mode=0750
-  with_items: nginx_auth_basic_files.keys()
+  with_items: "{{ nginx_auth_basic_files.keys() }}"
   tags: [configuration,nginx]
 
 - name: Create the configurations for sites
   template: src=site.conf.j2 dest={{nginx_conf_dir}}/sites-available/{{ item }}.conf
-  with_items: nginx_sites.keys() | difference(nginx_remove_sites)
+  with_items: "{{ nginx_sites.keys() | difference(nginx_remove_sites) }}"
   notify:
    - reload nginx
   tags: [configuration,nginx]
 
 - name: Create links for sites-enabled
   file: state=link src={{nginx_conf_dir}}/sites-available/{{ item }}.conf dest={{nginx_conf_dir}}/sites-enabled/{{ item }}.conf
-  with_items: nginx_sites.keys() | difference(nginx_remove_sites)
+  with_items: "{{ nginx_sites.keys() | difference(nginx_remove_sites) }}"
   notify:
    - reload nginx
   tags: [configuration,nginx]
 
 - name: Create the configurations for independent config file
   template: src=config.conf.j2 dest={{nginx_conf_dir}}/conf.d/{{ item }}.conf
-  with_items: nginx_configs.keys()
+  with_items: "{{ nginx_configs.keys() }}"
   notify:
    - reload nginx
   tags: [configuration,nginx]

--- a/tasks/installation.packages.yml
+++ b/tasks/installation.packages.yml
@@ -11,32 +11,32 @@
 
 - name: Install the nginx packages
   yum: name={{ item }} state=present disablerepo='*' enablerepo={{ "nginx," if nginx_official_repo else "" }}{{ yum_epel_repo }},{{ yum_base_repo }}
-  with_items: nginx_redhat_pkg
+  with_items: "{{ nginx_redhat_pkg }}"
   when:  nginx_is_el|bool
   tags: [packages,nginx]
 
 - name: Install the nginx packages
   yum: name={{ item }} state=present
-  with_items: nginx_redhat_pkg
+  with_items: "{{ nginx_redhat_pkg }}"
   when: ansible_os_family == "RedHat" and not nginx_is_el|bool
   tags: [packages,nginx]
 
 - name: Install the nginx packages
   apt: name={{ item }} state=present
-  with_items: nginx_ubuntu_pkg
+  with_items: "{{ nginx_ubuntu_pkg }}"
   environment: "{{ nginx_env }}"
   when: ansible_os_family == "Debian"
   tags: [packages,nginx]
 
 - name: Install the nginx packages
   pkgng: name={{ item }} state=present
-  with_items: nginx_freebsd_pkg
+  with_items: "{{ nginx_freebsd_pkg }}"
   environment: "{{ nginx_env }}"
   when: ansible_os_family == "FreeBSD"
   tags: [packages,nginx]
 
 - name: Install the nginx packages
   zypper: name={{ item }} state=present 
-  with_items: nginx_suse_pkg
+  with_items: "{{ nginx_suse_pkg }}"
   when: ansible_os_family == "Suse"
   tags: [packages,nginx]

--- a/tasks/remove-extras.yml
+++ b/tasks/remove-extras.yml
@@ -22,7 +22,7 @@
 
 - name: Remove unmanaged config files
   file: name={{nginx_conf_dir}}/conf.d/{{ item }} state=absent
-  with_items: config_files.stdout_lines
+  with_items: "{{ config_files.stdout_lines }}"
   # 'item.conf' => 'item'
   when: item[:-5] not in nginx_configs.keys()
   notify:

--- a/tasks/remove-unwanted.yml
+++ b/tasks/remove-unwanted.yml
@@ -3,22 +3,21 @@
   file: path={{nginx_conf_dir}}/{{ item[0] }}/{{ item[1] }}.conf state=absent
   with_nested: 
     - [ 'sites-enabled', 'sites-available']
-    - nginx_remove_sites
+    - "{{ nginx_remove_sites }}"
   notify:
    - reload nginx
   tags: [configuration,nginx]
 
 - name: Remove unwanted conf
   file: path={{nginx_conf_dir}}/conf.d/{{ item[1] }}.conf state=absent
-  with_items: nginx_remove_configs
+  with_items: "{{ nginx_remove_configs }}"
   notify:
    - reload nginx
   tags: [configuration,nginx]
 
 - name: Remove unwanted auth_basic_files
   file: path={{nginx_conf_dir}}/auth_basic/{{ item[1] }} state=absent
-  with_items: nginx_remove_auth_basic_files
+  with_items: "{{ nginx_remove_auth_basic_files }}"
   notify:
    - reload nginx
   tags: [configuration,nginx]
-  


### PR DESCRIPTION
This PR fixes all deprecation warnings introduced in 2.1.0:

`[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{nginx_remove_sites}}'). This 
feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.`
 