### PR TITLE
Fixed compatibility with ansible 2.x

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -27,7 +27,7 @@
   template: src=site.conf.j2 dest={{nginx_conf_dir}}/sites-available/{{ item }}.conf
   with_items: "{{ nginx_sites.keys() | difference(nginx_remove_sites) }}"
   notify:
-   - reload nginx
+   - restart nginx
   tags: [configuration,nginx]
 
 - name: Create links for sites-enabled

--- a/tasks/installation.packages.yml
+++ b/tasks/installation.packages.yml
@@ -10,7 +10,7 @@
   tags: [packages,nginx]
 
 - name: Install the nginx packages
-  yum: name={{ item }} state=present enablerepo={{ "nginx," if nginx_official_repo else "" }}
+  yum: name={{ item }} state=present disablerepo='*' enablerepo={{ "nginx," if nginx_official_repo else "" }}{{ yum_epel_repo }},{{ yum_base_repo }}
   with_items: "{{ nginx_redhat_pkg }}"
   when:  nginx_is_el|bool
   tags: [packages,nginx]
@@ -36,7 +36,7 @@
   tags: [packages,nginx]
 
 - name: Install the nginx packages
-  zypper: name={{ item }} state=present 
+  zypper: name={{ item }} state=present
   with_items: "{{ nginx_suse_pkg }}"
   when: ansible_os_family == "Suse"
   tags: [packages,nginx]

--- a/tasks/nginx-official-repo.yml
+++ b/tasks/nginx-official-repo.yml
@@ -1,26 +1,18 @@
 ---
 - name: Ensure APT official nginx key
   apt_key: url=http://nginx.org/keys/nginx_signing.key
-  environment: "{{ nginx_env }}"
   tags: [packages,nginx]
   when: ansible_os_family == 'Debian'
 
 - name: Ensure APT official nginx repository
   apt_repository: repo="deb http://nginx.org/packages/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} nginx"
-  environment: "{{ nginx_env }}"
   tags: [packages,nginx]
   when: ansible_os_family == 'Debian'
 
 - name: Ensure RPM official nginx key
   rpm_key: key=http://nginx.org/keys/nginx_signing.key
-  environment: "{{ nginx_env }}"
   when: ansible_os_family == 'RedHat'
 
 - name: Ensure YUM official nginx repository
   template: src=nginx.repo.j2 dest=/etc/yum.repos.d/nginx.repo
   when: ansible_os_family == 'RedHat'
-
-- name: Ensure zypper official nginx repository
-  zypper_repository: repo="http://nginx.org/packages/sles/12" name="nginx" disable_gpg_check=yes
-  environment: "{{ nginx_env }}"
-  when: ansible_distribution == 'SLES' and ansible_distribution_version == '12'

--- a/tasks/remove-extras.yml
+++ b/tasks/remove-extras.yml
@@ -1,13 +1,13 @@
 ---
 - name: Find enabled sites
-  shell: ls -1 {{nginx_conf_dir}}/sites-enabled || true
+  shell: ls -1 {{nginx_conf_dir}}/sites-enabled
   register: enabled_sites
   changed_when: False
   tags: [configuration,nginx]
 
 - name: Disable unmanaged sites
   file: path={{nginx_conf_dir}}/sites-enabled/{{ item }} state=absent
-  with_items: enabled_sites.stdout_lines
+  with_items: "{{ enabled_sites.stdout_lines }}"
   # 'item.conf' => 'item'
   when: item[:-5] not in nginx_sites.keys()
   notify:
@@ -28,4 +28,3 @@
   notify:
    - reload nginx
   tags: [configuration,nginx]
-

--- a/tasks/remove-unwanted.yml
+++ b/tasks/remove-unwanted.yml
@@ -1,8 +1,8 @@
 ---
 - name: Remove unwanted sites
   file: path={{nginx_conf_dir}}/{{ item[0] }}/{{ item[1] }}.conf state=absent
-  with_nested: 
-    - [ 'sites-enabled', 'sites-available']
+  with_nested:
+    - "{{ [ 'sites-enabled', 'sites-available'] }}"
     - "{{ nginx_remove_sites }}"
   notify:
    - reload nginx


### PR DESCRIPTION
This commit gets rid of the deprecation warnings caused by using Ansible 2.x
```
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your
playbooks so that the environment value uses the full variable syntax.
This feature will be removed in a future release.
Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
```