### PR TITLE
Allow use of a custom nginx.conf template

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,6 +52,10 @@ nginx_sites:
      - server_name _
      - root "{% if ansible_os_family == 'FreeBSD' %}/usr/local/www/nginx-dist{% else %}/usr/share/nginx/html{% endif %}"
      - index index.html
+
+tpls:
+  nginx_conf: "nginx.conf.j2"
+
 nginx_remove_sites: []
 
 nginx_configs: {}

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -13,7 +13,7 @@
   tags: [configuration,nginx]
 
 - name: Copy the nginx configuration file
-  template: src=nginx.conf.j2 dest={{nginx_conf_dir}}/nginx.conf
+  template: src={{tpls.nginx_conf}} dest={{nginx_conf_dir}}/nginx.conf
   notify:
    - restart nginx
   tags: [configuration,nginx]


### PR DESCRIPTION
While the default nginx.conf template obviously fits most people's needs and they should not have to be troubled about it, it sometimes does not. In my case because I like to keep the 4 spaces indent similar to nginx's defaults and, more importantly, because I do not use {{ nginx_conf_dir }}/conf.d/*.conf location and prefer to do so explicitly.

I would therefore propose keeping the current template location as a default but allow this to be overriden for users who prefer to.