### PR TITLE
Ensure that sites-enabled/sites-available/ directories exist before execute tasks which use them

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -1,17 +1,4 @@
 ---
-- name: Create the directories for site specific configurations
-  file: path={{nginx_conf_dir}}/{{ item }} state=directory owner=root group={{nginx_group}} mode=0755
-  with_items:
-    - "sites-available"
-    - "sites-enabled"
-    - "auth_basic"
-    - "conf.d"
-  tags: [configuration,nginx]
-
-- name: Ensure log directory exist
-  file: path={{ nginx_log_dir }} state=directory owner={{nginx_user}} group={{nginx_group}} mode=0755
-  tags: [configuration,nginx]
-
 - name: Copy the nginx configuration file
   template: src=nginx.conf.j2 dest={{nginx_conf_dir}}/nginx.conf
   notify:

--- a/tasks/ensure-dirs.yml
+++ b/tasks/ensure-dirs.yml
@@ -1,0 +1,14 @@
+---
+- name: Create the directories for site specific configurations
+  file: path={{nginx_conf_dir}}/{{ item }} state=directory owner=root group={{nginx_group}} mode=0755
+  with_items:
+    - "sites-available"
+    - "sites-enabled"
+    - "auth_basic"
+    - "conf.d"
+  tags: [configuration,nginx]
+
+- name: Ensure log directory exist
+  file: path={{ nginx_log_dir }} state=directory owner={{nginx_user}} group={{nginx_group}} mode=0755
+  tags: [configuration,nginx]
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   when: nginx_official_repo == True
 - include: installation.packages.yml
   when: nginx_installation_type == "packages"
+- include: ensure-dirs.yml
 - include: remove-defaults.yml
   when: not keep_only_specified
 - include: remove-extras.yml


### PR DESCRIPTION
This directories are used in ```remove-defaults.yml``` and ```remove-extras.yml```, it of course works even if they are not created yet (if they not exist - it is nothing to remove), but it would be clearer if they would be in place.