### PR TITLE
Add support for plain TCP loadbalancing

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ yum_epel_repo: epel
 yum_base_repo: base
 
 nginx_official_repo: False
+nginx_official_repo_mainline: False
 
 keep_only_specified: False
 
@@ -46,6 +47,8 @@ nginx_http_params:
   - server_tokens off
   - types_hash_max_size 2048
 
+nginx_stream_params: []
+
 nginx_sites:
   default:
      - listen 80 default_server
@@ -55,6 +58,7 @@ nginx_sites:
 nginx_remove_sites: []
 
 nginx_configs: {}
+nginx_stream_configs: {}
 nginx_remove_configs: []
 
 nginx_auth_basic_files: {}

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -30,3 +30,11 @@
   notify:
    - reload nginx
   tags: [configuration,nginx]
+
+- name: Create the configurations for independent config file for streams
+  template: src=config_stream.conf.j2 dest={{nginx_conf_dir}}/conf.d/stream/{{ item }}.conf
+  with_items: "{{ nginx_stream_configs.keys() }}"
+  notify:
+   - reload nginx
+  tags: [configuration,nginx]
+  when: nginx_official_repo_mainline

--- a/tasks/ensure-dirs.yml
+++ b/tasks/ensure-dirs.yml
@@ -6,6 +6,7 @@
     - "sites-enabled"
     - "auth_basic"
     - "conf.d"
+    - "conf.d/stream"
   tags: [configuration,nginx]
 
 - name: Ensure log directory exist

--- a/tasks/nginx-official-repo.yml
+++ b/tasks/nginx-official-repo.yml
@@ -9,7 +9,13 @@
   apt_repository: repo="deb http://nginx.org/packages/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} nginx"
   environment: "{{ nginx_env }}"
   tags: [packages,nginx]
-  when: ansible_os_family == 'Debian'
+  when: ansible_os_family == 'Debian' and not nginx_official_repo_mainline
+
+- name: Ensure APT official nginx repository (mainline)
+  apt_repository: repo="deb http://nginx.org/packages/mainline/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} nginx"
+  environment: "{{ nginx_env }}"
+  tags: [packages,nginx]
+  when: ansible_os_family == 'Debian' and nginx_official_repo_mainline
 
 - name: Ensure RPM official nginx key
   rpm_key: key=http://nginx.org/keys/nginx_signing.key
@@ -23,4 +29,9 @@
 - name: Ensure zypper official nginx repository
   zypper_repository: repo="http://nginx.org/packages/sles/12" name="nginx" disable_gpg_check=yes
   environment: "{{ nginx_env }}"
-  when: ansible_distribution == 'SLES' and ansible_distribution_version == '12'
+  when: ansible_distribution == 'SLES' and ansible_distribution_version == '12' and not nginx_official_repo_mainline
+
+- name: Ensure zypper official nginx repository (mainline)
+  zypper_repository: repo="http://nginx.org/packages/mainline/sles/12" name="nginx" disable_gpg_check=yes
+  environment: "{{ nginx_env }}"
+  when: ansible_distribution == 'SLES' and ansible_distribution_version == '12' and nginx_official_repo_mainline

--- a/templates/config_stream.conf.j2
+++ b/templates/config_stream.conf.j2
@@ -1,0 +1,9 @@
+#{{ ansible_managed }}
+
+{% for v in nginx_stream_configs[item] %}
+{% if v.find('\n') != -1 %}
+{{v}}
+{% else %}
+{% if v != "" %}{{ v.replace(";",";\n   ").replace(" {"," {\n    ").replace(" }"," \n}\n") }}{% if v.find('{') == -1%};
+{% endif %}{% endif %}{% endif %}
+{% endfor %}

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -28,6 +28,17 @@ http {
         include {{ nginx_conf_dir }}/sites-enabled/*;
 }
 
+{% if nginx_official_repo_mainline %}
+stream {
+
+{% for v in nginx_stream_params %}
+        {{ v }};
+{% endfor %}
+
+        include {{ nginx_conf_dir }}/conf.d/stream/*.conf;
+}
+{% endif %}
+
 {% if nginx_daemon_mode == "off" %}
 daemon off;
 {% endif %}

--- a/templates/nginx.repo.j2
+++ b/templates/nginx.repo.j2
@@ -1,4 +1,8 @@
 [nginx]
 name=nginx repo
+{% if nginx_official_repo_mainline %}
+baseurl=http://nginx.org/packages/mainline/{{"rhel" if ansible_distribution == "RedHat" else "centos"}}/{{ansible_distribution_version.split('.')[0]}}/{{ansible_architecture}}/
+{% else %}
 baseurl=http://nginx.org/packages/{{"rhel" if ansible_distribution == "RedHat" else "centos"}}/{{ansible_distribution_version.split('.')[0]}}/{{ansible_architecture}}/
+{% endif %}
 enabled=1


### PR DESCRIPTION
This adds a `nginx_stream_params` variable to allow configuring the [stream module](http://nginx.org/en/docs/stream/ngx_stream_core_module.html).

Please note that to use this you have to use Nginx 1.9 or a newer one. This adds an `nginx_official_repo_mainline` variable that allows using the mainline repo with the newest stable version.

To use the stream feature you have to have both `nginx_official_repo` and `nginx_official_repo_mainline` set to `True`.

With `nginx_official_repo_mainline` set to `False` (the default) the module behavior does not change and it continues to work with older versions of Nginx.

I'm open to suggestions, so please don't hesitate if you'd like to see something done differently.