### PR TITLE
Add mainline installation to possibilites 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ yum_epel_repo: epel
 yum_base_repo: base
 
 nginx_official_repo: False
+nginx_mainline_repo: False
 
 keep_only_specified: False
 

--- a/tasks/installation.packages.yml
+++ b/tasks/installation.packages.yml
@@ -10,7 +10,7 @@
   tags: [packages,nginx]
 
 - name: Install the nginx packages
-  yum: name={{ item }} state=present enablerepo={{ "nginx," if nginx_official_repo else "" }}
+  yum: name={{ item }} state=present enablerepo={{ "nginx," if nginx_official_repo or nginx_mainline_repo else "" }}
   with_items: "{{ nginx_redhat_pkg }}"
   when:  nginx_is_el|bool
   tags: [packages,nginx]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - include: nginx-official-repo.yml
   when: nginx_official_repo == True
+- include: nginx-mainline-repo.yml
+  when: nginx_mainline_repo == True
 - include: installation.packages.yml
   when: nginx_installation_type == "packages"
 - include: remove-defaults.yml

--- a/tasks/nginx-mainline-repo.yml
+++ b/tasks/nginx-mainline-repo.yml
@@ -21,6 +21,6 @@
   when: ansible_os_family == 'RedHat'
 
 - name: Ensure zypper official nginx repository
-  zypper_repository: repo="http://nginx.org/packages/sles/12" name="nginx" disable_gpg_check=yes
+  zypper_repository: repo="http://nginx.org/packages/mainline/sles/12" name="nginx" disable_gpg_check=yes
   environment: "{{ nginx_env }}"
   when: ansible_distribution == 'SLES' and ansible_distribution_version == '12'

--- a/tasks/nginx-mainline-repo.yml
+++ b/tasks/nginx-mainline-repo.yml
@@ -1,0 +1,26 @@
+---
+- name: Ensure APT official nginx key
+  apt_key: url=http://nginx.org/keys/nginx_signing.key
+  environment: "{{ nginx_env }}"
+  tags: [packages,nginx]
+  when: ansible_os_family == 'Debian'
+
+- name: Ensure APT official nginx repository
+  apt_repository: repo="deb http://nginx.org/packages/mainline/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} nginx"
+  environment: "{{ nginx_env }}"
+  tags: [packages,nginx]
+  when: ansible_os_family == 'Debian'
+
+- name: Ensure RPM official nginx key
+  rpm_key: key=http://nginx.org/keys/nginx_signing.key
+  environment: "{{ nginx_env }}"
+  when: ansible_os_family == 'RedHat'
+
+- name: Ensure YUM official nginx repository
+  template: src=nginx_mainline.repo.j2 dest=/etc/yum.repos.d/nginx.repo
+  when: ansible_os_family == 'RedHat'
+
+- name: Ensure zypper official nginx repository
+  zypper_repository: repo="http://nginx.org/packages/sles/12" name="nginx" disable_gpg_check=yes
+  environment: "{{ nginx_env }}"
+  when: ansible_distribution == 'SLES' and ansible_distribution_version == '12'

--- a/templates/nginx.repo.j2
+++ b/templates/nginx.repo.j2
@@ -1,4 +1,4 @@
 [nginx]
-name=nginx repo
+name=nginx
 baseurl=http://nginx.org/packages/{{"rhel" if ansible_distribution == "RedHat" else "centos"}}/{{ansible_distribution_version.split('.')[0]}}/{{ansible_architecture}}/
 enabled=1

--- a/templates/nginx_mainline.repo.j2
+++ b/templates/nginx_mainline.repo.j2
@@ -1,0 +1,4 @@
+[nginx]
+name=nginx
+baseurl=http://nginx.org/packages/mainline/{{"rhel" if ansible_distribution == "RedHat" else "centos"}}/{{ansible_distribution_version.split('.')[0]}}/{{ansible_architecture}}/
+enabled=1


### PR DESCRIPTION
In this case you can install the latest nginx version from the mainline repository. From the original repository you are able to install 1.6 version while from the mainline it is possible to install the 1.9.x