### PR TITLE
allow null config definitions

### DIFF
--- a/templates/config.conf.j2
+++ b/templates/config.conf.j2
@@ -1,6 +1,6 @@
 #{{ ansible_managed }}
 
-{% if nginx_sites[item] != None %}
+{% if nginx_configs[item] != None %}
 {% for v in nginx_configs[item] %}
 {% if v.find('\n') != -1 %}
 {{v}}

--- a/templates/config.conf.j2
+++ b/templates/config.conf.j2
@@ -1,5 +1,6 @@
 #{{ ansible_managed }}
 
+{% if nginx_sites[item] != None %}
 {% for v in nginx_configs[item] %}
 {% if v.find('\n') != -1 %}
 {{v}}
@@ -7,3 +8,4 @@
 {% if v != "" %}{{ v.replace(";",";\n   ").replace(" {"," {\n    ").replace(" }"," \n}\n") }}{% if v.find('{') == -1%};
 {% endif %}{% endif %}{% endif %}
 {% endfor %}
+{% endif %}

--- a/templates/site.conf.j2
+++ b/templates/site.conf.j2
@@ -1,4 +1,5 @@
 #{{ ansible_managed }}
+{% if nginx_sites[item] != None %}
 server {
 {% for v in nginx_sites[item] %}
 {% if v.find('\n') != -1 %}
@@ -8,3 +9,4 @@ server {
 {% endif %}{% endif %}{% endif %}
 {% endfor %}
 }
+{% endif %}


### PR DESCRIPTION
Without this change, there's no good way to remove or wipe an existing `server{}` definition file.