### PR TITLE
add nginx_error_log_level

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Additional configuration are created in /etc/nginx/conf.d/
 - hosts: all
   roles:
     - role: nginx
+      nginx_error_log_level: info
       nginx_http_params:
         - sendfile on
         - access_log /var/log/nginx/access.log

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,6 +33,7 @@ nginx_pid_file: '/var/run/{{nginx_service_name}}.pid'
 nginx_worker_processes: "{% if ansible_processor_vcpus is defined %}{{ ansible_processor_vcpus }}{% else %}auto{% endif %}"
 nginx_worker_rlimit_nofile: 1024
 nginx_log_dir: "/var/log/nginx"
+nginx_error_log_level: "error"
 
 nginx_events_params:
   - worker_connections {% if nginx_max_clients is defined %}{{nginx_max_clients}}{% else %}512{% endif %}
@@ -43,7 +44,7 @@ nginx_http_params:
   - tcp_nodelay "on"
   - keepalive_timeout "65"
   - access_log "{{nginx_log_dir}}/access.log"
-  - error_log "{{nginx_log_dir}}/error.log"
+  - "error_log {{nginx_log_dir}}/error.log {{nginx_error_log_level}}"
   - server_tokens off
   - types_hash_max_size 2048
 


### PR DESCRIPTION
This patch provides configurability for alternative error_log levels as in http://nginx.org/en/docs/ngx_core_module.html#error_log