### PR TITLE
add nginx_remove_default flag to disable default site

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,6 +61,7 @@ nginx_remove_sites: []
 nginx_configs: {}
 nginx_stream_configs: {}
 nginx_remove_configs: []
+nginx_remove_default: False
 
 nginx_auth_basic_files: {}
 nginx_remove_auth_basic_files: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,20 @@
 ---
 - include: nginx-official-repo.yml
   when: nginx_official_repo == True
+
 - include: installation.packages.yml
   when: nginx_installation_type == "packages"
+
 - include: ensure-dirs.yml
+
 - include: remove-defaults.yml
-  when: not keep_only_specified
+  when: not keep_only_specified or nginx_remove_default
+
 - include: remove-extras.yml
   when: keep_only_specified
+
 - include: remove-unwanted.yml
+
 - include: configuration.yml
 
 - name: Start the nginx service


### PR DESCRIPTION
wanted to remove *default* site but keep unmanaged sites (so don't want to enable `keep_only_specified`).
