### PR TITLE
Remove whitespace to fix ansible-lint issue

### DIFF
--- a/tasks/remove-unwanted.yml
+++ b/tasks/remove-unwanted.yml
@@ -1,7 +1,7 @@
 ---
 - name: Remove unwanted sites
   file: path={{nginx_conf_dir}}/{{ item[0] }}/{{ item[1] }}.conf state=absent
-  with_nested: 
+  with_nested:
     - [ 'sites-enabled', 'sites-available']
     - "{{ nginx_remove_sites }}"
   notify:


### PR DESCRIPTION
It causes a failure running ansible-lint.