### PR TITLE
GH-118 Fix idempotency and don't delete the conf.d/stream directory.

### DIFF
--- a/tasks/remove-extras.yml
+++ b/tasks/remove-extras.yml
@@ -15,7 +15,7 @@
   tags: [configuration,nginx]
 
 - name: Find config files
-  shell: ls -1 {{nginx_conf_dir}}/conf.d
+  shell: find {{nginx_conf_dir}}/conf.d -maxdepth 1 -type f -name '*.conf' -exec basename {} \;
   register: config_files
   changed_when: False
   tags: [configuration,nginx]


### PR DESCRIPTION
Fix for https://github.com/jdauphant/ansible-role-nginx/issues/118

Only removed unmanaged files (not directories) inside ```conf.d``` so that the ```/etc/nginx/conf.d/stream``` is not added and then removed on each Ansible run.
