### PR TITLE
conditional for epel

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,8 +12,7 @@ nginx_freebsd_pkg:
 nginx_suse_pkg:
   - nginx
 
-yum_epel_repo: epel
-yum_base_repo: base
+nginx_install_epel_repo: True
 
 nginx_official_repo: False
 nginx_official_repo_mainline: False

--- a/tasks/installation.packages.yml
+++ b/tasks/installation.packages.yml
@@ -6,7 +6,7 @@
 
 - name: Install the epel packages
   yum: name=epel-release state=present
-  when: nginx_is_el|bool and yum_epel_repo
+  when: nginx_is_el|bool and nginx_install_epel_repo|bool
   tags: [packages,nginx]
 
 - name: Install the nginx packages

--- a/tasks/installation.packages.yml
+++ b/tasks/installation.packages.yml
@@ -6,7 +6,7 @@
 
 - name: Install the epel packages
   yum: name=epel-release state=present
-  when: nginx_is_el|bool
+  when: nginx_is_el|bool and yum_epel_repo
   tags: [packages,nginx]
 
 - name: Install the nginx packages


### PR DESCRIPTION
This minor change allows the caller to set `yum_epel_repo: False` and the role will not try to install epel-release. I have a use case for this because we manage our own repositories that explicitly provide everything that we need without relying on the vagaries of EPEL.