### PR TITLE
Avoid deprecation warning

### DIFF
--- a/tasks/remove-extras.yml
+++ b/tasks/remove-extras.yml
@@ -7,7 +7,7 @@
 
 - name: Disable unmanaged sites
   file: path={{nginx_conf_dir}}/sites-enabled/{{ item }} state=absent
-  with_items: enabled_sites.stdout_lines
+  with_items: "{{ enabled_sites.stdout_lines | default([]) }}"
   # 'item.conf' => 'item'
   when: item[:-5] not in nginx_sites.keys()
   notify:


### PR DESCRIPTION
Avoid deprecation warning for unquoted with_items variable and add an empy array as default for the cases where enabled_sites is not defined (like when running with check-mode/dry-run).