### PR TITLE
Add openresty support for RHEL and CentOS

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
+nginx_openresty: False
+
 nginx_redhat_pkg:
-  - nginx
+  - "{% if nginx_openresty %}openresty{% else %}nginx{% endif %}"
 
 nginx_ubuntu_pkg:
   - python-selinux
@@ -20,11 +22,11 @@ nginx_official_repo_mainline: False
 keep_only_specified: False
 
 nginx_installation_type: "packages"
-nginx_binary_name: "nginx"
+nginx_binary_name: "{% if nginx_openresty %}openresty{% else %}nginx{% endif %}"
 nginx_service_name: "{{nginx_binary_name}}"
-nginx_conf_dir: "{% if ansible_os_family == 'FreeBSD' %}/usr/local/etc/nginx{% else %}/etc/nginx{% endif %}"
+nginx_conf_dir: "{% if ansible_os_family == 'FreeBSD' %}/usr/local/etc/nginx{% elif nginx_openresty%}/usr/local/openresty/nginx/conf{% else %}/etc/nginx{% endif %}"
 
-nginx_user: "{% if ansible_os_family == 'RedHat' or ansible_os_family == 'Suse' %}nginx{% elif ansible_os_family == 'Debian' %}www-data{% elif ansible_os_family == 'FreeBSD' %}www{% endif %}"
+nginx_user: "{% if nginx_openresty %}openresty{% elif ansible_os_family == 'RedHat' or ansible_os_family == 'Suse' %}nginx{% elif ansible_os_family == 'Debian' %}www-data{% elif ansible_os_family == 'FreeBSD' %}www{% endif %}"
 nginx_group: "{{nginx_user}}"
 
 nginx_pid_file: '/var/run/{{nginx_service_name}}.pid'

--- a/tasks/installation.packages.yml
+++ b/tasks/installation.packages.yml
@@ -10,7 +10,7 @@
   tags: [packages,nginx]
 
 - name: Install the nginx packages
-  yum: name={{ item }} state=present enablerepo={{ "nginx" if nginx_official_repo else "" }}
+  yum: name={{ item }} state=present enablerepo="{% if nginx_official_repo %}nginx{% elif nginx_openresty %}openresty{% endif %}"
   with_items: "{{ nginx_redhat_pkg }}"
   when:  nginx_is_el|bool
   tags: [packages,nginx]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,12 @@
 ---
 - include: nginx-official-repo.yml
-  when: nginx_official_repo == True
+  when: nginx_official_repo == True and nginx_openresty != True
+- include: openresty-repo.yml
+  when: nginx_openresty == True and nginx_official_repo != True
 - include: installation.packages.yml
   when: nginx_installation_type == "packages"
+- include: openresty-service.yml
+  when: nginx_openresty == True and nginx_official_repo != True
 - include: ensure-dirs.yml
 - include: remove-defaults.yml
   when: not keep_only_specified

--- a/tasks/openresty-repo.yml
+++ b/tasks/openresty-repo.yml
@@ -1,0 +1,9 @@
+---
+- name: Ensure openresty RPM repository key
+  rpm_key: key=https://copr-be.cloud.fedoraproject.org/results/openresty/openresty/pubkey.gpg
+  environment: "{{ nginx_env }}"
+  when: ansible_os_family == 'RedHat'
+
+- name: Ensure openresty repository
+  template: src=openresty.repo.j2 dest=/etc/yum.repos.d/openresty.repo
+  when: ansible_os_family == 'RedHat'

--- a/tasks/openresty-service.yml
+++ b/tasks/openresty-service.yml
@@ -1,0 +1,19 @@
+---
+- name: "Add the {{ nginx_user }} group"
+  group:
+    name: "{{nginx_user}}"
+    system: true
+
+- name: "Add the {{ nginx_user }} user"
+  user:
+    name: "{{nginx_user}}"
+    system: true
+    shell: /sbin/nologin
+    group: "{{ nginx_user }}"
+    home: /dev/null
+
+- name: Add a systemd unit file for openresty
+  template:
+    src: openresty.service.j2
+    dest: /etc/systemd/system/openresty.service
+  when: ansible_service_mgr == 'systemd'

--- a/templates/openresty.repo.j2
+++ b/templates/openresty.repo.j2
@@ -1,0 +1,12 @@
+[openresty]
+name=Official OpenResty Repository
+{% if ansible_distribution == "CentOS" %}
+baseurl=https://copr-be.cloud.fedoraproject.org/results/openresty/openresty/epel-$releasever-$basearch/
+{% else %}
+baseurl=https://copr-be.cloud.fedoraproject.org/results/openresty/openresty/epel-{{ansible_distribution_major_version}}-$basearch/
+{% endif %}
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/openresty/openresty/pubkey.gpg
+enabled=1
+enabled_metadata=1

--- a/templates/openresty.service.j2
+++ b/templates/openresty.service.j2
@@ -1,0 +1,22 @@
+[Unit]
+Description=The nginx HTTP and reverse proxy server
+After=network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=forking
+PIDFile=/run/openresty.pid
+# Nginx will fail to start if /run/openresty.pid already exists but has the wrong
+# SELinux context. This might happen when running `nginx -t` from the cmdline.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1268621
+ExecStartPre=/usr/bin/rm -f /run/nginx.pid
+ExecStartPre=/usr/local/openresty/nginx/sbin/nginx -t -c {{ nginx_conf_dir }}/nginx.conf
+ExecStart=/usr/local/openresty/nginx/sbin/nginx -c {{ nginx_conf_dir }}/nginx.conf
+#ExecReload=/usr/local/openresty/nginx/sbin/nginx -s reload -c {{ nginx_conf_dir }}/nginx.conf
+ExecReload=/bin/kill -s HUP $MAINPID
+KillSignal=SIGQUIT
+TimeoutStopSec=5
+KillMode=process
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Feel free to close if this extends the role too much.

This PR adds support for the openresty flavour of nginx for CentOS and RHEL. By setting the new `nginx_openresty` variable to `true`, the openresty repository is added and openresty installed from that repository.

Furthermore, nginx is configured in the correct directory, an openresty group and user are created and a systemd unit file is installed.

Tested on CentOS 7.
