### PR TITLE
Add possibility to additional configuration of the main context

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,6 +34,7 @@ nginx_worker_rlimit_nofile: 1024
 nginx_log_dir: "/var/log/nginx"
 nginx_error_log_level: "error"
 
+nginx_extra_root_params: ""
 nginx_events_params:
   - worker_connections {% if nginx_max_clients is defined %}{{nginx_max_clients}}{% else %}512{% endif %}
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -9,6 +9,10 @@ pid        {{ nginx_pid_file }};
 
 worker_rlimit_nofile {{ nginx_worker_rlimit_nofile }};
 
+{% if nginx_extra_root_params %}
+{{ nginx_extra_root_params }}
+{% endif %}
+
 events {
 {% for v in nginx_events_params %}
         {{ v }};


### PR DESCRIPTION
Now we can add more options to main config context, e.g.:
```
user www-data  www-data;
worker_processes  auto;
pid /var/run/nginx.pid;
worker_rlimit_nofile 1024;
include /etc/nginx/modules-enabled/*.conf; # extra option

http {
...
}
```