### PR TITLE
Use dict for nginx_extra_root_params instead string

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,7 @@ nginx_worker_rlimit_nofile: 1024
 nginx_log_dir: "/var/log/nginx"
 nginx_error_log_level: "error"
 
-nginx_extra_root_params: ""
+nginx_extra_root_params: []
 nginx_events_params:
   - worker_connections {% if nginx_max_clients is defined %}{{nginx_max_clients}}{% else %}512{% endif %}
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -9,8 +9,10 @@ pid        {{ nginx_pid_file }};
 
 worker_rlimit_nofile {{ nginx_worker_rlimit_nofile }};
 
-{% if nginx_extra_root_params %}
-{{ nginx_extra_root_params }}
+{% if nginx_extra_root_params is defined and nginx_extra_root_params is iterable %}
+{% for line in nginx_extra_root_params %}
+{{ line }};
+{% endfor %}
 {% endif %}
 
 events {


### PR DESCRIPTION
For your comment for yesterday's PR. Now we need to write something like this. 
```
nginx_extra_root_params:
  - include /etc/nginx/modules-enabled/*.conf
```