### PR TITLE
Add block support to nginx_http_params

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -27,7 +27,11 @@ http {
         include {{ nginx_conf_dir }}/mime.types;
         default_type application/octet-stream;
 {% for v in nginx_http_params %}
-        {{ v }};
+{% if v.find('\n') != -1 %}
+   {{v.replace("\n","\n   ")}}
+{% else %}
+   {% if v != "" %}{{ v.replace(";",";\n      ").replace(" {"," {\n      ").replace(" }"," \n   }\n") }}{% if v.find('{') == -1%};
+{% endif %}{% endif %}{% endif %}
 {% endfor %}
 
         include {{ nginx_conf_dir }}/conf.d/*.conf;


### PR DESCRIPTION
Copy code from site.conf.j2 for support blocks in nginx_http_params. For example I want add server block to http for global redirect from www to non-www.