### PR TITLE
Accommodate custom templates for site conf files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 ------------
 
 This role requires Ansible 1.4 or higher and platform requirements are listed
-in the metadata file.  
+in the metadata file.
 For FreeBSD a working pkgng setup is required (see: https://www.freebsd.org/doc/handbook/pkgng-intro.html )
 
 Role Variables
@@ -259,6 +259,46 @@ Additional configuration are created in /etc/nginx/conf.d/
                - root "/usr/share/nginx/html"
                - index index.html
 ```
+8) Site configuration using a custom template.
+Instead of defining a site config file using a list of attributes,
+you may use a hash that indicates an alternate template.
+Additional hash elements are accessible inside the template through
+the `nginx_sites[item]` hash.
+```yaml
+- hosts: all
+
+  roles:
+  - role: nginx
+    nginx_sites:
+      bar:
+        template: bar.conf.j2
+        server_name: bar.example.com
+```
+Custom template: bar.conf.j2:
+```handlebars
+# {{ ansible_managed }}
+upstream backend {
+  server backend1.example.com weight=5;
+  server backend2.example.com:8080;
+  server unix:/tmp/backend3;
+
+  server backup1.example.com:8080 backup;
+  server backup2.example.com:8080 backup;
+}
+server {
+  server_name {{nginx_sites[item].server_name}};
+  location / {
+    proxy_pass http://backend;
+  }
+}
+```
+Using a custom template allows for unlimited flexibility in configuring the site config file.
+This example demonstrates the common practice of configuring a site server block
+in the same file as its complementary upstream block.
+If you use this option:
+* _The hash **must** include a `template:` value, or the configuration task will fail._
+* _This role cannot check tha validity of your custom template.
+It is up to you to provide a template with valid content and formatting for NGINX._
 
 Dependencies
 ------------

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -17,7 +17,7 @@
 
 - name: Create the configurations for sites
   template:
-    src: site.conf.j2
+    src: "{{ nginx_sites[item].template | default('site.conf.j2') }}"
     dest: "{{nginx_conf_dir}}/sites-available/{{ item }}.conf"
   with_items: "{{ nginx_sites.keys() | difference(nginx_remove_sites) }}"
   notify:


### PR DESCRIPTION
Two considerations:

1) The current implementation for site config files wraps each site's directives in a `server` block.  While this is arguably the "proper" way to define a site, it prevents standard idioms like including a site's corresponding upstream definition in the same file (for example the standard NGINX/unicorn setup.)  There is real value in combining as site .conf with its upstream, because it allows you to enable/disable/modify a site and its upstreams together.

2) In most cases, the implementor will have an existing .conf file to start with.  For simple configs, it's easy to migrate the NGINX directives to use with this role.  But for more complex configurations, it's not helpful to have to break down a file into an array of directives, hoping in the end this role will reassemble the directives to get _right back to the original file you started with._

Without compromising existing functionality, this solution provides a way to use a custom template to define a site .conf file.  The most obvious use-case for this is to copy a desired .conf file verbatim.