### PR TITLE
fix settings with quotes in sites template

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,6 +22,10 @@ galaxy_info:
    - name: FreeBSD
      versions:
       - 10.0
+      - 10.1
+      - 10.2
+      - 10.3
+      - 11.0
   categories:
    - web
 allow_duplicates: yes

--- a/templates/site.conf.j2
+++ b/templates/site.conf.j2
@@ -3,8 +3,6 @@ server {
 {% for v in nginx_sites[item] %}
 {% if v.find('\n') != -1 %}
    {{v.replace("\n","\n   ")}}
-{% elif v[-1:] == '"' %}
-   {{ v }};
 {% else %}
    {% if v != "" %}{{ v.replace(";",";\n      ").replace(" {"," {\n      ").replace(" }"," \n   }\n") }}{% if v.find('{') == -1%};
 {% endif %}{% endif %}{% endif %}

--- a/templates/site.conf.j2
+++ b/templates/site.conf.j2
@@ -3,6 +3,8 @@ server {
 {% for v in nginx_sites[item] %}
 {% if v.find('\n') != -1 %}
    {{v.replace("\n","\n   ")}}
+{% elif v[-1:] == '"' %}
+   {{ v }};
 {% else %}
    {% if v != "" %}{{ v.replace(";",";\n      ").replace(" {"," {\n      ").replace(" }"," \n   }\n") }}{% if v.find('{') == -1%};
 {% endif %}{% endif %}{% endif %}


### PR DESCRIPTION
Adding a setting with quotes like this in nginx_sites:
add_header X-XSS-Protection "1; mode=block"

results in the following beeing generated in the config file : 
   add_header X-XSS-Protection "1;
       mode=block"; 

Some software are having trouble with multiline headers like this.
This is due to the template confusing raw configuration and quoted settings. This PR fixes the issue.

Also, mark FreeBSD versions up to 11.0 as compatible.