### PR TITLE
Compatibility with Fedora

### DIFF
--- a/tasks/installation.packages.yml
+++ b/tasks/installation.packages.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install the selinux python module
-  yum: name=libselinux-python state=present
+  package: name=libselinux-python state=present
   when: ansible_os_family == "RedHat"
 
 - name: Install the epel packages
@@ -13,7 +13,7 @@
   when:  nginx_is_el|bool
 
 - name: Install the nginx packages
-  yum: name={{ item }} state=present
+  package: name={{ item }} state=present
   with_items: "{{ nginx_redhat_pkg }}"
   when: ansible_os_family == "RedHat" and not nginx_is_el|bool
 


### PR DESCRIPTION
In `meta.yml` this role claims to be compatible with Fedora. This is not the case because recent versions of Fedora use dnf instead of yum for package management. This PR makes this role compatible again by using the general package module.

While doing this changes, I thought that the whole set of installation tasks could be simplified by utilizing the package module and the fact that the package name is almost always just nginx on all platforms. But I leave this up to you to decide if a cleanup is reasonable.