### PR TITLE
Always_run is deprecated #161

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -18,7 +18,7 @@
   command: "{{ nginx_binary_name }} -t"
   register: result
   changed_when: "result.rc != 0"
-  always_run: yes
+  check_mode: no
   when: nginx_installation_type in nginx_installation_types_using_service
 
 - name: restart nginx - after config check

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -49,4 +49,4 @@
   with_dict: "{{ nginx_stream_configs }}"
   notify:
    - reload nginx
-  when: nginx_official_repo_mainline
+  when: nginx_stream_params is defined and nginx_stream_configs is defined

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -34,7 +34,7 @@ http {
         include {{ nginx_conf_dir }}/sites-enabled/*;
 }
 
-{% if nginx_official_repo_mainline %}
+{% if nginx_stream_params or nginx_stream_params %}
 stream {
 
 {% for v in nginx_stream_params %}


### PR DESCRIPTION
It is required to prefer check_mode: no 

It remove a warning during deployement