### PR TITLE
Use installed nginx version to determine stream support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,5 +29,6 @@ galaxy_info:
   categories:
    - web
 allow_duplicates: yes
-dependencies: []
+dependencies:
+  - atosatto.packages-extras
 

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -49,4 +49,4 @@
   with_dict: "{{ nginx_stream_configs }}"
   notify:
    - reload nginx
-  when: nginx_official_repo_mainline
+  when: nginx_official_repo_mainline or (nginx_installed_version | version_compare('1.9.0', '>='))

--- a/tasks/installation.packages.yml
+++ b/tasks/installation.packages.yml
@@ -13,3 +13,27 @@
   with_items: "{{ nginx_pkgs }}"
   environment: "{{ nginx_env }}"
   when: not nginx_is_el|bool or not nginx_official_repo
+
+- name: Determine nginx version (Debian)
+  apt_madison:
+    name: "{{ nginx_pkgs[0] }}"
+  changed_when: False
+  register: nginx_version_result
+  when: ansible_os_family == 'Debian'
+
+- name: set nginx_installed_version
+  set_fact:
+    nginx_installed_version: "{{ nginx_version_result.versions | map(attribute='version') | first }}"
+  when: not (nginx_version_result.skipped | default(False) | bool)
+
+- name: Determine nginx version (RPM)
+  apt_madison:
+    name: "{{ nginx_pkgs[0] }}"
+  changed_when: False
+  register: nginx_version_result
+  when: ansible_os_family == 'RedHat' or ansible_distribution == 'SLES'
+
+- name: set nginx_installed_version
+  set_fact:
+    nginx_installed_version: "{{ nginx_version_result.versions | map(attribute='version') | first }}"
+  when: not (nginx_version_result.skipped | default(False) | bool)

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -34,7 +34,7 @@ http {
         include {{ nginx_conf_dir }}/sites-enabled/*;
 }
 
-{% if nginx_official_repo_mainline %}
+{% if nginx_official_repo_mainline or (nginx_installed_version | version_compare('1.9.0', '>=')) %}
 stream {
 
 {% for v in nginx_stream_params %}


### PR DESCRIPTION
This PR dynamically sets a fact called `nginx_installed_version` that is then used to determine whether or not stream support is available. This comes in handy e.g. when nginx from jessie-backports is installed, as it is a version higher than 1.9.0, but not from the mainline repo.

The version is determined using https://github.com/atosatto/ansible-packages-extras 