### PR TITLE
Add support for configuration snippets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ script:
   - cat /etc/nginx/conf.d/upstream.conf
   - cat /etc/nginx/conf.d/geo.conf
   - cat /etc/nginx/conf.d/gzip.conf
+  - cat /etc/nginx/snippets/error_pages.conf
   - sudo cat /etc/nginx/auth_basic/demo
   - sudo nginx -t
 after_script:

--- a/README.md
+++ b/README.md
@@ -323,6 +323,35 @@ If you use this option:
 If you use this method, the conf file formatting provided by this role is unavailable,
 and it is up to you to provide a template with valid content and formatting for NGINX._
 
+10) Install Nginx, add 2 sites, use snippets to configure access controls
+```yaml
+---
+- hosts: all
+  roles:
+    - role: nginx
+      nginx_http_params:
+        - sendfile on
+        - access_log /var/log/nginx/access.log
+      nginx_snippets:
+        accesslist_devel:
+          - allow 192.168.0.0/24
+          - deny all
+      nginx_sites:
+        foo:
+           - listen 8080
+           - server_name localhost
+           - root /tmp/site1
+           - include snippets/accesslist_devel.conf
+           - location / { try_files $uri $uri/ /index.html; }
+           - location /images/ { try_files $uri $uri/ /index.html; }
+        bar:
+           - listen 9090
+           - server_name ansible
+           - root /tmp/site2
+           - location / { try_files $uri $uri/ /index.html; }
+           - location /images/ { try_files $uri $uri/ /index.html; }
+```
+
 Dependencies
 ------------
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ nginx_configs:
       - gzip on
       - gzip_disable msie6
 
+# A list of hashes that define configuration snippets
+nginx_snippets:
+  error_pages:
+    - error_page 500 /http_errors/500.html
+    - error_page 502 /http_errors/502.html
+    - error_page 503 /http_errors/503.html
+    - error_page 504 /http_errors/504.html
+
 # A list of hashes that define user/password files
 nginx_auth_basic_files:
    demo:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,8 +41,10 @@ nginx_sites:
 nginx_remove_sites: []
 
 nginx_configs: {}
+nginx_snippets: {}
 nginx_stream_configs: {}
 nginx_remove_configs: []
+nginx_remove_snippets: []
 
 nginx_auth_basic_files: {}
 nginx_remove_auth_basic_files: []

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -42,6 +42,14 @@
   notify:
    - reload nginx
 
+- name: Create configuration snippets
+  template:
+    src: config.conf.j2
+    dest: "{{ nginx_conf_dir }}/snippets/{{ item.key }}.conf"
+  with_dict: "{{ nginx_snippets }}"
+  notify:
+   - reload nginx
+
 - name: Create the configurations for independent config file for streams
   template:
     src: config_stream.conf.j2

--- a/tasks/ensure-dirs.yml
+++ b/tasks/ensure-dirs.yml
@@ -12,6 +12,7 @@
     - "auth_basic"
     - "conf.d"
     - "conf.d/stream"
+    - "snippets"
 
 - name: Ensure log directory exist
   file:

--- a/tasks/remove-unwanted.yml
+++ b/tasks/remove-unwanted.yml
@@ -17,6 +17,14 @@
   notify:
    - reload nginx
 
+- name: Remove unwanted snippets
+  file:
+    path: "{{ nginx_conf_dir }}/snippets/{{ item[1] }}.conf"
+    state: absent
+  with_items: "{{ nginx_remove_snippets }}"
+  notify:
+   - reload nginx
+
 - name: Remove unwanted auth_basic_files
   file:
     path: "{{nginx_conf_dir}}/auth_basic/{{ item[1] }}"

--- a/test/example-vars.yml
+++ b/test/example-vars.yml
@@ -71,6 +71,14 @@ nginx_configs:
       - gzip on
       - gzip_disable msie6
 
+# A list of hashes that define configuration snippets
+nginx_snippets:
+  error_pages:
+    - error_page 500 /http_errors/500.html
+    - error_page 502 /http_errors/502.html
+    - error_page 503 /http_errors/503.html
+    - error_page 504 /http_errors/504.html
+
 # A list of hashs that define uer/password files
 nginx_auth_basic_files:
    demo:


### PR DESCRIPTION
It may be useful to have configuration snippets to include in some other
configuration files (access list, error pages, TLS settings, etc).