### PR TITLE
Fix meta/main syntax

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,30 +4,29 @@ galaxy_info:
   license: BSD
   min_ansible_version: 2.0
   platforms:
-   - name: EL
-     versions:
-      - all
-   - name: Fedora
-     versions:
-      - all
-   - name: opensuse
-     versions:
-      - all
-   - name: Ubuntu
-     versions:
-      - all
-   - name: Debian
-     versions:
-      - all
-   - name: FreeBSD
-     versions:
-      - 10.0
-      - 10.1
-      - 10.2
-      - 10.3
-      - 11.0
-  categories:
-   - web
+  - name: EL
+    versions:
+    - all
+  - name: Fedora
+    versions:
+    - all
+  - name: opensuse
+    versions:
+    - all
+  - name: Ubuntu
+    versions:
+    - all
+  - name: Debian
+    versions:
+    - all
+  - name: FreeBSD
+    versions:
+    - 10.0
+    - 10.1
+    - 10.2
+    - 10.3
+    - 11.0
+  galaxy_tags:
+  - web
 allow_duplicates: yes
 dependencies: []
-


### PR DESCRIPTION
I reindented lists as in `galaxy init` template, replaced `categories` to `galaxy_tags` and removed second `\n` at end of file. ansible-lint executed with metacloud/molecule fails tests.