### PR TITLE
Load config from nginx_confdir/modules-enabled

### DIFF
--- a/tasks/ensure-dirs.yml
+++ b/tasks/ensure-dirs.yml
@@ -13,6 +13,8 @@
     - "conf.d"
     - "conf.d/stream"
     - "snippets"
+    - "modules-available"
+    - "modules-enabled"
 
 - name: Ensure log directory exist
   file:

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -9,6 +9,8 @@ pid        {{ nginx_pid_file }};
 
 worker_rlimit_nofile {{ nginx_worker_rlimit_nofile }};
 
+include {{ nginx_conf_dir }}/modules-enabled/*.conf;
+
 {% if nginx_extra_root_params is defined and nginx_extra_root_params is iterable %}
 {% for line in nginx_extra_root_params %}
 {{ line }};


### PR DESCRIPTION
In Debian Stretch (and backported versions of nginx to Jessie), nginx
modules are installed as separate packages and their `load` directives
are moved to `/etc/nginx/modules-enabled/*.conf`.

Closes #166