### PR TITLE
Add stream config when one of the vars is defined

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -57,4 +57,4 @@
   with_dict: "{{ nginx_stream_configs }}"
   notify:
    - reload nginx
-  when: nginx_official_repo_mainline
+  when: nginx_stream_params or nginx_stream_configs

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -34,7 +34,7 @@ http {
         include {{ nginx_conf_dir }}/sites-enabled/*;
 }
 
-{% if nginx_official_repo_mainline %}
+{% if nginx_stream_params or nginx_stream_configs %}
 stream {
 
 {% for v in nginx_stream_params %}


### PR DESCRIPTION
Before, nginx_mainline_repo was used to identify a modern enough nginx.
Unfortunately, distros are catching up (e.g. Debian Stretch) and support
the streams module.

If nginx_stream_params or nginx_stream_configs are not empty, a `stream`
block is included in `nginx.conf`.

Closes #160