### PR TITLE
the replacement of ';' is incorrect if ';' in a paramter.

### DIFF
--- a/templates/site.conf.j2
+++ b/templates/site.conf.j2
@@ -5,7 +5,7 @@ server {
 {% if v.find('\n') != -1 %}
    {{v.replace("\n","\n   ")}}
 {% else %}
-   {% if v != "" %}{{ v.replace(";",";\n      ").replace(" {"," {\n      ").replace(" }"," \n   }\n") }}{% if v.find('{') == -1%};
+   {% if v != "" %}{{ v.replace(";(\n| *$)",";\n      ").replace(" {"," {\n      ").replace(" }"," \n   }\n") }}{% if v.find('{') == -1%};
 {% endif %}{% endif %}{% endif %}
 {% endfor %}
 }


### PR DESCRIPTION
for example:
`   add_header Content-Disposition 'attachment; filename="$arg__upd"';
`
the configuration file will be rewrite to:
```
   add_header Content-Disposition 'attachment;
   filename="$arg__upd"';
```