### PR TITLE
Fix typo in Readme about nginx default var

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ for details.
 # retain defaults and add additional `client_max_body_size` param
   roles:
     - role: jdauphant.nginx
-      nginx_http_params: "{{ nginx_http_params_defaults + my_extra_params }}"
+      nginx_http_params: "{{ nginx_http_default_params + my_extra_params }}"
 ```
 
 Note: Each site added is represented by a list of hashes, and the configurations


### PR DESCRIPTION
The variable `nginx_http_params_defaults` was mispelled in the README.
The real variable name, as declared in vars/main.yml is
`nginx_http_default_params`.