### PR TITLE
CVE 2016-1247

### DIFF
--- a/tasks/ensure-dirs.yml
+++ b/tasks/ensure-dirs.yml
@@ -20,6 +20,6 @@
   file:
     path: "{{ nginx_log_dir }}"
     state: directory
-    owner: "{{nginx_user}}"
-    group: "{{nginx_group}}"
+    owner: "root"
+    group: "adm"
     mode: 0755


### PR DESCRIPTION
According to CVE-2016-1247 /var/log/nginx shouldnot be owned by www-data
Not sure if that patch brakes it for other distros, only tested on debian.

more info: https://legalhackers.com/advisories/Nginx-Exploit-Deb-Root-PrivEsc-CVE-2016-1247.html