### PR TITLE
remove default.conf in ubuntu16

### DIFF
--- a/tasks/remove-defaults.yml
+++ b/tasks/remove-defaults.yml
@@ -1,8 +1,11 @@
 ---
 - name: Disable the default site
   file:
-    path: "{{nginx_conf_dir}}/sites-enabled/default"
+    path: "{{nginx_conf_dir}}/sites-enabled/{{item}}"
     state: absent
+  with_items:
+    - default
+    - default.conf
   notify:
   - reload nginx
 


### PR DESCRIPTION
On ubuntu16, `default` is called `default.conf`. This PR adds `default.conf` to the list of default files to remove in the task `Disable the default site`