### PR TITLE
Accept blocks on http params

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -29,7 +29,7 @@ http {
         include {{ nginx_conf_dir }}/mime.types;
         default_type application/octet-stream;
 {% for v in nginx_http_params %}
-        {{ v }};
+        {{ v if "}" in v[-2:] else v+";" }}
 {% endfor %}
 
         include {{ nginx_conf_dir }}/conf.d/*.conf;


### PR DESCRIPTION
Problem: nginx blocks "{}" could not be used on nginx_http_params since
a semicolon will end up appended, making the configtest to fail

This solution also allows the use of the YAML pipe "|" that which appends a
new line add the end of the string