### PR TITLE
Fix CVE-2016-1247 vol2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,8 @@ nginx_pid_file: '/var/run/{{nginx_service_name}}.pid'
 nginx_worker_processes: "{% if ansible_processor_vcpus is defined %}{{ ansible_processor_vcpus }}{% else %}auto{% endif %}"
 nginx_worker_rlimit_nofile: 1024
 nginx_log_dir: "/var/log/nginx"
+nginx_log_user: "{% if ansible_os_family == 'Debian' %}root{% else %}{{nginx_user}}{% endif %}"
+nginx_log_group: "{% if ansible_os_family == 'Debian' %}adm{% else %}{{nginx_group}}{% endif %}"
 nginx_error_log_level: "error"
 
 nginx_extra_root_params: []

--- a/tasks/ensure-dirs.yml
+++ b/tasks/ensure-dirs.yml
@@ -20,6 +20,6 @@
   file:
     path: "{{ nginx_log_dir }}"
     state: directory
-    owner: "{{nginx_user}}"
-    group: "{{nginx_group}}"
+    owner: "{{nginx_log_user}}"
+    group: "{{nginx_log_group}}"
     mode: 0755

--- a/tasks/ensure-dirs.yml
+++ b/tasks/ensure-dirs.yml
@@ -4,7 +4,7 @@
     path: "{{nginx_conf_dir}}/{{ item }}"
     state: directory
     owner: root
-    group: "{{nginx_group}}"
+    group: root
     mode: 0755
   with_items:
     - "sites-available"


### PR DESCRIPTION
Using the solution suggested in #174

Now on Debian log directory has correct permissions and shouldnot brake any other distros.
I think everything in /etc/nginx should be owned by root  group rather then nginx_group, why should webscripts group own something in /etc/nginx ? 