### PR TITLE
Removed keepalive_timeout and types_hash_max_size

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,4 @@
 ---
-
 nginx_env:
   RUNLEVEL: 1
 
@@ -8,11 +7,10 @@ nginx_installation_types_using_service: ["packages", "configuration-only"]
 nginx_is_el: "{{ ansible_distribution in ['RedHat', 'CentOS'] }}"
 
 nginx_http_default_params:
-  - sendfile "on"
-  - tcp_nopush "on"
-  - tcp_nodelay "on"
-  - keepalive_timeout "65"
+  - sendfile on
+  - tcp_nopush on
+  - tcp_nodelay on
+  - server_tokens off  
   - access_log "{{nginx_log_dir}}/access.log"
-  - "error_log {{nginx_log_dir}}/error.log {{nginx_error_log_level}}"
-  - server_tokens off
-  - types_hash_max_size 2048
+  - error_log "{{nginx_log_dir}}/error.log" {{nginx_error_log_level}}
+  


### PR DESCRIPTION
keepalive_timeout and types_hash_max_size are performance related settings and it should be left to the admin to decide what their values should be if they are not happy with nginx's built-in defaults. Defining these in `vars/main.yml` causes more pain because it makes it hard to override (the only way is by passing in a new version of `nginx_http_default_params` as a role var or on the command line, which is a strange place to do it given these are supposed to be generic defaults),

Example: I prefer `keepalive_timeout 30 30` for all of my hosts but currently have to define this in every `nginx_sites` entry because I can't set it once via an include using `nginx_configs` (nginx will complain of a duplicate setting and refuse to start).