### PR TITLE
Fix #196 put back the group on basic auth file

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -11,6 +11,7 @@
     src: auth_basic.j2
     dest: "{{ nginx_conf_dir }}/auth_basic/{{ item.key }}"
     mode: 0750
+    group: "{{ nginx_group }}"
   with_dict: "{{ nginx_auth_basic_files }}"
 
 - name: Create the configurations for sites


### PR DESCRIPTION
group on basic auth file have been removed by the previous commit, but
it imply the error
   open() "/etc/nginx/auth_basic/foo" failed (14: Permission denied)

Add it back in order to allow nginx to read the basif auth file