### PR TITLE
Fix removal of configs and snippets

### DIFF
--- a/tasks/remove-unwanted.yml
+++ b/tasks/remove-unwanted.yml
@@ -11,7 +11,7 @@
 
 - name: Remove unwanted conf
   file:
-    path: "{{nginx_conf_dir}}/conf.d/{{ item[1] }}.conf"
+    path: "{{nginx_conf_dir}}/conf.d/{{ item }}.conf"
     state: absent
   with_items: "{{ nginx_remove_configs }}"
   notify:
@@ -19,7 +19,7 @@
 
 - name: Remove unwanted snippets
   file:
-    path: "{{ nginx_conf_dir }}/snippets/{{ item[1] }}.conf"
+    path: "{{ nginx_conf_dir }}/snippets/{{ item }}.conf"
     state: absent
   with_items: "{{ nginx_remove_snippets }}"
   notify:


### PR DESCRIPTION
Removing of configs and snippets does not work. This is the same bug that was fixed in #189 that should have been done on these 2 lines also.