### PR TITLE
Add possibility to not enable the sites that we don't want to be enabled

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,7 @@ nginx_sites:
     - root "{{ nginx_sites_default_root }}" 
     - index index.html
 nginx_remove_sites: []
+nginx_disabled_sites: []
 
 nginx_configs: {}
 nginx_snippets: {}

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -29,7 +29,7 @@
     src: "{{ nginx_conf_dir }}/sites-available/{{ item.key }}.conf"
     dest: "{{ nginx_conf_dir }}/sites-enabled/{{ item.key }}.conf"
   with_dict: "{{ nginx_sites }}"
-  when: item.key not in nginx_remove_sites
+  when: (item.key not in nginx_remove_sites) and (item.key not in nginx_disabled_sites)
   notify:
     - reload nginx
 


### PR DESCRIPTION
Sometimes it's feasible to leave site not enabled after running nginx role.

E. g. if we want to use nginx role to pre-configure the site, then automatically obtain an ssl certificate via letsencrypt (that requires nginx to be running) and do some additional configuration steps before we finally enable the site.

If a site is mentioned in **nginx_disabled_sites** list, then no link to .conf file is created from 'sites-availiable' to 'sites-enabled'.