### PR TITLE
Make folder-permissions configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,7 @@ keep_only_specified: False
 nginx_installation_type: "packages"
 nginx_binary_name: "nginx"
 nginx_service_name: "{{nginx_binary_name}}"
-nginx_conf_dir: /etc/nginx # For this variable, a specific value for the OS can be apply in vars/{{ ansible_os_family }}.yml 
+nginx_conf_dir: /etc/nginx # For this variable, a specific value for the OS can be apply in vars/{{ ansible_os_family }}.yml
 nginx_default_site_template: "site.conf.j2"
 
 nginx_user: nginx  # For this variable, a specific value for the OS can be apply in vars/{{ ansible_os_family }}.
@@ -25,10 +25,12 @@ nginx_worker_rlimit_nofile: 1024
 nginx_log_dir: "/var/log/nginx"
 nginx_log_user: "{% if ansible_os_family == 'Debian' %}root{% else %}{{nginx_user}}{% endif %}"
 nginx_log_group: "{% if ansible_os_family == 'Debian' %}adm{% else %}{{nginx_group}}{% endif %}"
+nginx_log_perm: 0755
 nginx_error_log_level: "error"
 
 nginx_conf_user: root
 nginx_conf_group: root
+nginx_dir_perm: 0755
 
 nginx_extra_root_params: []
 nginx_events_params:
@@ -44,7 +46,7 @@ nginx_sites:
   default:
     - listen 80 default_server
     - server_name _
-    - root "{{ nginx_sites_default_root }}" 
+    - root "{{ nginx_sites_default_root }}"
     - index index.html
 nginx_remove_sites: []
 

--- a/tasks/ensure-dirs.yml
+++ b/tasks/ensure-dirs.yml
@@ -5,7 +5,7 @@
     state: directory
     owner: "{{ nginx_conf_user }}"
     group: "{{ nginx_conf_group }}"
-    mode: 0755
+    mode: "{{nginx_dir_perm}}"
   with_items:
     - "sites-available"
     - "sites-enabled"
@@ -22,4 +22,4 @@
     state: directory
     owner: "{{nginx_log_user}}"
     group: "{{nginx_log_group}}"
-    mode: 0755
+    mode: "{{nginx_log_perm}}"


### PR DESCRIPTION
This PR will make this role compatible to [dev-sec.nginx-hardening](https://github.com/dev-sec/ansible-nginx-hardening) (step "config should not be worldwide read- or writeable"
) by configuring `nginx_dir_perm: 0750` or `nginx_dir_perm: 0751`.

Nothing will change by default (however this will allow to configure a server more securely while keeping the playbook idempotent).

Currently, the folder-permissions are changed to 0755 by this role, and 0751 by the hardening role. This PR will allow to reconfigure this behaviour.
