### PR TITLE
Revert "Change user, as which nginx is running (#209)"

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,7 @@ nginx_service_name: "{{nginx_binary_name}}"
 nginx_conf_dir: /etc/nginx # For this variable, a specific value for the OS can be apply in vars/{{ ansible_os_family }}.yml
 nginx_default_site_template: "site.conf.j2"
 
-nginx_user: "{{nginx_default_user}}"
+nginx_user: nginx  # For this variable, a specific value for the OS can be apply in vars/{{ ansible_os_family }}.
 nginx_group: "{{nginx_user}}"
 
 nginx_pid_file: '/var/run/{{nginx_service_name}}.pid'

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,2 +1,2 @@
 ---
-nginx_default_user: www-data
+nginx_user: www-data

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -1,5 +1,5 @@
 ---
 nginx_conf_dir: /usr/local/etc/nginx
-nginx_default_user: www
+nginx_user: www
 nginx_sites_default_root: /usr/local/www/nginx-dist
 nginx_conf_group: wheel

--- a/vars/Solaris.yml
+++ b/vars/Solaris.yml
@@ -1,4 +1,4 @@
 ---
 nginx_conf_dir: /opt/local/etc/nginx
-nginx_default_user: www
+nginx_user: www
 nginx_sites_default_root: /opt/local/www

--- a/vars/empty.yml
+++ b/vars/empty.yml
@@ -1,3 +1,2 @@
 ---
 # This file intentionally does not define any variables.
-nginx_defaut_user: nginx


### PR DESCRIPTION
This reverts commit b90cc285dda400f617ce2adb7d38b9646accd15c.

@jdauphant I found this morning that there was a new 2.15 release out, because my Nginx provisioning stopped working on CentOS 7:

![screen shot 2018-03-17 at 10 23 59](https://user-images.githubusercontent.com/786326/37553751-57c061b8-29ce-11e8-9f9f-834549ac35b7.png)

The problem seem to be that when evaluating this line in `defaults/main.yml`— the only place where `nginx_default_user` is read —we find that it is not defined.

```yml
    nginx_log_user: "{% if ansible_os_family == 'Debian' %}root{% else %}{{nginx_user}}{% endif %}"
```

In essence, with the fix to #207 that is release 2.15, this Ansible role now **only** works on Debian (because then default user isn't read at all). 

Kindly proposing to merge this commit-revert as release 2.16.

@krzyzakp Maybe there's a better way of overriding default user?
