### PR TITLE
Configure start server during the role run and/or at boot

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,6 +61,10 @@ nginx_auth_basic_files: {}
 nginx_remove_auth_basic_files: []
 
 nginx_daemon_mode: "on"
+# Set wether to start the service during the role run or keep it stopped
+nginx_start_service: true
+# Set wether enable Nginx service on boot or not
+nginx_start_at_boot: true
 
 nginx_set_real_ip_from_cloudflare: False
 nginx_cloudflare_real_ip_header: "CF-Connecting-IP" # See: https://support.cloudflare.com/hc/en-us/articles/200170706-How-do-I-restore-original-visitor-IP-with-Nginx-

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -23,8 +23,12 @@
 
 - name: restart nginx - after config check
   service: name={{ nginx_service_name }} state=restarted
-  when: nginx_installation_type in nginx_installation_types_using_service and nginx_daemon_mode == "on"
+  when: nginx_installation_type in nginx_installation_types_using_service
+        and nginx_daemon_mode == "on"
+        and nginx_start_service
 
 - name: reload nginx - after config check
   service: name={{ nginx_service_name }} state=reloaded
-  when: nginx_installation_type in nginx_installation_types_using_service and nginx_daemon_mode == "on"
+  when: nginx_installation_type in nginx_installation_types_using_service
+        and nginx_daemon_mode == "on"
+        and nginx_start_service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,6 @@
   tags: [configuration, nginx]
 
 - name: Start the nginx service
-  service: name={{ nginx_service_name }} state=started enabled=yes
+  service: name={{ nginx_service_name }} state={{nginx_start_service | ternary('started', 'stopped')}} enabled={{nginx_start_at_boot}}
   when: nginx_installation_type in nginx_installation_types_using_service and nginx_daemon_mode == "on"
   tags: [service, nginx]

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,7 +10,6 @@ nginx_http_default_params:
   - sendfile on
   - tcp_nopush on
   - tcp_nodelay on
-  - server_tokens off  
+  - server_tokens off
   - access_log "{{nginx_log_dir}}/access.log"
   - error_log "{{nginx_log_dir}}/error.log" {{nginx_error_log_level}}
-  


### PR DESCRIPTION
Sometimes is not necessary to start Nginx during the role run, so I added the option `nginx_start_service`, by default `true`. I also added `nginx_start_at_boot`, which sets if Nginx should be enabled to start when the machine boots. It defaults to `true` too. The defaults ensure backwards compatibility

The motivation for this change is for those cases where you have a active-passive Nginx servers and you have a 3rd party application starting or stopping them (like heartbeat, pacemaker, or similar). This is important when you have your Nginxs behind (for instance) a AWS ALB, both at the same time, but you cannot serve both at the same time so you keep one down and the other started with some of the 3rd parties utils I mention before.

I understand this can be a very particular case, but all in all will give more flexibility to the role _if needed_, after all defaults don't change the actual behavior of the role.