### PR TITLE
Add option to include or not vars/{{ansible_os_family}}.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,9 @@ nginx_official_repo_mainline: False
 
 nginx_keep_only_specified: "{{ keep_only_specified | default(False) }}"
 
+# Whether load vars/{{ ansible_os_family }}.yml or not
+nginx_load_default_vars: true
+
 nginx_installation_type: "packages"
 nginx_binary_name: "nginx"
 nginx_service_name: "{{nginx_binary_name}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
   with_first_found:
     - "../vars/{{ ansible_os_family }}.yml"
     - "../vars/empty.yml"
+  when: nginx_load_default_vars
   tags: [always]
 
 - include: selinux.yml


### PR DESCRIPTION
Without this option, is impossible to set `nginx_user` outside the role (in the playbook, via group_vars, or wherever), because it is *always* overwritten by the `include_vars`.

`nginx_load_default_vars` is added and defaults to `true`, so it is backwards compatible.