### PR TITLE
#186: Replace obsolete "include" statements by "include_tasks" and "import_tasks"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,26 +7,26 @@
   when: nginx_load_default_vars
   tags: [always]
 
-- import_tasks: selinux.yml
+- include_tasks: selinux.yml
   when: ansible_selinux and ansible_selinux.status == "enabled"
   tags: [packages, selinux, nginx]
 
-- import_tasks: nginx-official-repo.yml
+- include_tasks: nginx-official-repo.yml
   when: nginx_official_repo == True
   tags: [packages, nginx]
 
-- import_tasks: installation.packages.yml
+- include_tasks: installation.packages.yml
   when: nginx_installation_type == "packages"
   tags: [packages, nginx]
 
 - import_tasks: ensure-dirs.yml
   tags: [configuration, nginx]
 
-- import_tasks: remove-defaults.yml
+- include_tasks: remove-defaults.yml
   when: not nginx_keep_only_specified
   tags: [configuration, nginx]
 
-- import_tasks: remove-extras.yml
+- include_tasks: remove-extras.yml
   when: nginx_keep_only_specified
   tags: [configuration, nginx]
 
@@ -36,7 +36,7 @@
 - import_tasks: configuration.yml
   tags: [configuration, nginx]
 
-- include: cloudflare_configuration.yml
+- include_tasks: cloudflare_configuration.yml
   when: nginx_set_real_ip_from_cloudflare == True
   tags: [configuration, nginx]
 


### PR DESCRIPTION
Issue: #186, PR: https://github.com/jdauphant/ansible-role-nginx/pull/188

### Changes

- One `include` has not been replaced.
- The `import_tasks` is a static include and it won't work if one of the variables in `when` condition will be changed in a runtime.