### PR TITLE
Support Nginx Amplify

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ nginx_auth_basic_files:
 
 # Enable Real IP for CloudFlare requests
 nginx_set_real_ip_from_cloudflare: True
+
+# Enable Nginx Amplify
+nginx_amplify: true
+nginx_amplify_api_key: "your_api_key_goes_here"
+nginx_amplify_update_agent: true
 ```
 
 Examples

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Requirements
 This role requires Ansible 2.4 or higher and platform requirements are listed
 in the metadata file. (Some older version of the role support Ansible 1.4)
 For FreeBSD a working pkgng setup is required (see: https://www.freebsd.org/doc/handbook/pkgng-intro.html )
+Installation of Nginx Amplify agent is only supported on CentOS, RedHat, Amazon, Debian and Ubuntu distributions.
 
 Install
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,3 +72,9 @@ nginx_start_at_boot: true
 nginx_set_real_ip_from_cloudflare: False
 nginx_cloudflare_real_ip_header: "CF-Connecting-IP" # See: https://support.cloudflare.com/hc/en-us/articles/200170706-How-do-I-restore-original-visitor-IP-with-Nginx-
 nginx_cloudflare_configuration_name: "cloudflare" # Name for the conf file in the conf.d directory
+
+nginx_amplify: false
+nginx_amplify_api_key: ""
+nginx_amplify_update_agent: false
+nginx_amplify_script_url: "https://github.com/nginxinc/nginx-amplify-agent/raw/master/packages/install.sh"
+nginx_amplify_script_path: "/tmp/install-amplify-agent.sh"

--- a/tasks/amplify.yml
+++ b/tasks/amplify.yml
@@ -1,0 +1,41 @@
+---
+- name: Check if Amplify Agent is installed
+  package:
+    name: nginx-amplify-agent
+    state: present
+  ignore_errors: true
+  register: amplify_agent_installed
+
+- name: Install Amplify Agent if not installed
+  block:
+    - name: Download Amplify Agent script
+      get_url:
+        url: "{{ nginx_amplify_script_url }}"
+        dest: "{{ nginx_amplify_script_path }}"
+
+    - name: Run Amplify Agent install.sh script
+      command: "sh /tmp/install-amplify-agent.sh -y"
+      environment:
+        API_KEY: "{{ amplify.api_key }}"
+      become: true
+      become_user: root
+      become_method: sudo
+
+    - name: Remove installation script
+      file:
+        path: "{{ nginx_amplify_script_path }}"
+        state: absent
+
+  when: amplify_agent_installed.failed == true
+
+- name: Update Amplify Agent if installed already and update flag is enabled
+  package:
+    name: nginx-amplify-agent
+    state: latest
+  when: amplify_agent_installed.failed == false and nginx_amplify_update_agent == true
+
+- name: Veriy Amplify agent is up and running
+  service:
+    name: amplify-agent
+    state: started
+    enabled: true

--- a/tasks/amplify.yml
+++ b/tasks/amplify.yml
@@ -5,6 +5,7 @@
     state: present
   ignore_errors: true
   register: amplify_agent_installed
+  tags: [packages]
 
 - name: Install Amplify Agent if not installed
   block:
@@ -27,15 +28,18 @@
         state: absent
 
   when: amplify_agent_installed.failed == true
+  tags: [configuration, packages]
 
-- name: Update Amplify Agent if installed already and update flag is enabled
+- name: Update Amplify Agent if already installed and update flag is enabled
   package:
     name: nginx-amplify-agent
     state: latest
   when: amplify_agent_installed.failed == false and nginx_amplify_update_agent == true
+  tags: [packages]
 
-- name: Veriy Amplify agent is up and running
+- name: Verify Amplify agent is up and running
   service:
     name: amplify-agent
     state: started
     enabled: true
+  tags: [service]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,7 @@
   tags: [configuration, nginx]
 
 - include_tasks: amplify.yml
-  when: nginx_amplify == True
+  when: nginx_amplify == true and (ansible_distribution in ['RedHat', 'CentOS', 'Debian', 'Amazon', 'Ubuntu'])
   tags: [amplify]
 
 - name: Start the nginx service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
 
 - include_tasks: amplify.yml
   when: nginx_amplify == true and (ansible_distribution in ['RedHat', 'CentOS', 'Debian', 'Amazon', 'Ubuntu'])
-  tags: [amplify]
+  tags: [amplify, nginx]
 
 - name: Start the nginx service
   service: name={{ nginx_service_name }} state={{nginx_start_service | ternary('started', 'stopped')}} enabled={{nginx_start_at_boot}}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,6 +42,7 @@
 
 - include_tasks: amplify.yml
   when: nginx_amplify == True
+  tags: [configuration, nginx, amplify]
 
 - name: Start the nginx service
   service: name={{ nginx_service_name }} state={{nginx_start_service | ternary('started', 'stopped')}} enabled={{nginx_start_at_boot}}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,9 @@
   when: nginx_set_real_ip_from_cloudflare == True
   tags: [configuration, nginx]
 
+- include_tasks: amplify.yml
+  when: nginx_amplify == True
+
 - name: Start the nginx service
   service: name={{ nginx_service_name }} state={{nginx_start_service | ternary('started', 'stopped')}} enabled={{nginx_start_at_boot}}
   when: nginx_installation_type in nginx_installation_types_using_service and nginx_daemon_mode == "on"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
 
 - include_tasks: amplify.yml
   when: nginx_amplify == True
-  tags: [configuration, nginx, amplify]
+  tags: [amplify]
 
 - name: Start the nginx service
   service: name={{ nginx_service_name }} state={{nginx_start_service | ternary('started', 'stopped')}} enabled={{nginx_start_at_boot}}


### PR DESCRIPTION
We recently had to add support for Nginx Amplify to one of our client's Nginx instances and introduced the necessary steps in our playbooks since it did not seem that this role supports it. We have been using this role for quite a while now and we figured it was time to contribute something back :).

The tasks were based off of Nginx's official Ansible role (which does support Amplify), and also the recommended steps when attempting to add a new server on the Amplify website.

If there are any points of feedback with respect to the PR just let us know :).