### PR TITLE
Setting the nginx configuration file in the "check nginx configuration" handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,7 +15,7 @@
     - reload nginx - after config check
 
 - name: check nginx configuration
-  command: "{{ nginx_binary_name }} -t"
+  command: "{{ nginx_binary_name }} -t -c {{ nginx_conf_dir }}/nginx.conf"
   register: result
   changed_when: "result.rc != 0"
   check_mode: no


### PR DESCRIPTION
Explicitly setting the nginx configuration file in the "check nginx configuration" handler. This is required whenever you're not using the default value.