### PR TITLE
Fixing Ansible 2.7.0 deprication warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ script:
   - ansible-lint tasks/main.yml
   - echo localhost > inventory
   - ansible-playbook -i inventory --syntax-check --list-tasks test/test.yml -e "role_name=ansible-role-nginx" -e "hosts_group=hosts_group"
-  - ansible-playbook -i inventory --connection=local --sudo -vvvv test/test.yml -u root -e "role_name=ansible-role-nginx" -e "hosts_group=localhost"
+  - ansible-playbook -i inventory --connection=local --become -vvvv test/test.yml -u root -e "role_name=ansible-role-nginx" -e "hosts_group=localhost"
   - >
-      ansible-playbook -i inventory --connection=local --sudo -vvvv test/test.yml -u root -e "role_name=ansible-role-nginx" -e "hosts_group=localhost"
+      ansible-playbook -i inventory --connection=local --become -vvvv test/test.yml -u root -e "role_name=ansible-role-nginx" -e "hosts_group=localhost"
       | grep -q 'changed=0.*failed=0'
       && (echo 'Idempotence test: pass' && exit 0)
       || (echo 'Idempotence test: fail' && exit 1)

--- a/tasks/amplify.yml
+++ b/tasks/amplify.yml
@@ -43,4 +43,3 @@
     state: started
     enabled: true
   tags: [service]
-

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -30,6 +30,7 @@
     dest: "{{ nginx_conf_dir }}/sites-enabled/{{ item.key }}.conf"
   with_dict: "{{ nginx_sites }}"
   when: (item.key not in nginx_remove_sites) and (item.key not in nginx_disabled_sites)
+  ignore_errors: "{{ ansible_check_mode }}"
   notify:
     - reload nginx
 

--- a/tasks/installation.packages.yml
+++ b/tasks/installation.packages.yml
@@ -4,12 +4,10 @@
   when: nginx_is_el|bool and nginx_install_epel_repo|bool
 
 - name: Install the nginx packages from official repo for EL distributions
-  yum: name={{ item }} state=present enablerepo="nginx"
-  with_items: "{{ nginx_pkgs }}"
+  yum: name="{{ nginx_pkgs }}" state=present enablerepo="nginx"
   when: nginx_is_el|bool and nginx_official_repo
 
 - name: Install the nginx packages for all other distributions
-  package: name={{ item }} state=present
-  with_items: "{{ nginx_pkgs }}"
+  package: name="{{ nginx_pkgs }}" state=present
   environment: "{{ nginx_env }}"
   when: not nginx_is_el|bool or not nginx_official_repo

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -1,17 +1,7 @@
 ---
 - name: Install the selinux python module
-  package: name={{ item }} state=present
-  with_items:
-    - libselinux-python
-    - libsemanage-python
-  when: ansible_os_family == "RedHat"
-
-- name: Install the selinux python module
-  package: name={{ item }} state=present
-  with_items:
-    - python-selinux
-    - python-semanage
-  when: ansible_os_family == "Debian"
+  package: name={{ nginx_python_selinux_pkgs | default(omit)}} state=present
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
 
 - name: Set SELinux boolean to allow nginx to set rlimit
   seboolean: name=httpd_setrlimit state=yes persistent=yes

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,2 +1,6 @@
 ---
 nginx_user: www-data
+
+nginx_python_selinux_pkgs:
+  - python-selinux
+  - python-semanage

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,4 @@
+---
+nginx_python_selinux_pkgs:
+  - libselinux-python
+  - libsemanage-python

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,3 +13,5 @@ nginx_http_default_params:
   - server_tokens off
   - access_log "{{nginx_log_dir}}/access.log"
   - error_log "{{nginx_log_dir}}/error.log" {{nginx_error_log_level}}
+
+nginx_python_selinux_pkgs: []


### PR DESCRIPTION
* Remving travis deprecation warning - Moving from "--sudo" to "--become"
* For further details take a look at: https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.7.html#using-a-loop-on-a-package-module-via-squash-actions