### PR TITLE
Add support to declare nginx modules in config file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,10 @@ nginx_sites:
 nginx_remove_sites: []
 nginx_disabled_sites: []
 
+nginx_module_configs: []
+nginx_remove_modules: []
+nginx_disabled_modules: []
+
 nginx_configs: {}
 nginx_snippets: {}
 nginx_stream_configs: {}

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -58,3 +58,22 @@
   notify:
     - reload nginx
   when: nginx_stream_params or nginx_stream_configs
+
+- name: Create configuration for modules
+  template:
+    src: module.conf.j2
+    dest: "{{ nginx_conf_dir }}/modules-available/{{ item }}.conf"
+  loop: "{{ nginx_module_configs }}"
+  notify:
+    - reload nginx
+
+- name: Create links for modules-enabled
+  file:
+    state: link
+    src: "{{ nginx_conf_dir }}/modules-available/{{ item }}.conf"
+    dest: "{{ nginx_conf_dir }}/modules-enabled/{{ item }}.conf"
+  with_items: "{{ nginx_module_configs }}"
+  when: (item not in nginx_remove_modules) and (item not in nginx_disabled_modules)
+  ignore_errors: "{{ ansible_check_mode }}"
+  notify:
+    - reload nginx

--- a/templates/module.conf.j2
+++ b/templates/module.conf.j2
@@ -1,3 +1,3 @@
 #{{ ansible_managed }}
 
-load_module "/usr/lib64/nginx/modules/{{ item }}.so";
+load_module "modules/{{ item }}.so";

--- a/templates/module.conf.j2
+++ b/templates/module.conf.j2
@@ -1,0 +1,3 @@
+#{{ ansible_managed }}
+
+load_module "/usr/lib64/nginx/modules/{{ item }}.so";


### PR DESCRIPTION
Dear Julien,
I have added few changes to your project "ansible-role-nginx" and add support to declare modules. 
My example playbook : 

```yaml
- hosts: all
  roles:
    - role: ansible-role-nginx
      nginx_http_params:
        - sendfile on
        - access_log /var/log/nginx/access.log
        - error_log /var/log/nginx/error.log
        - include snippets/geoip.conf
     nginx_module_configs:
        - ngx_http_geoip_module
      nginx_snippets:
        geoip:
          -    geoip_country /usr/share/GeoIP/GeoIP.dat;
                map $geoip_country_code $allowed_country {
                default yes;
                IR no;
                CN no;
            }
```
And next I just add geoip functions into virtual hosts. 

Thanks,
Dmitry 

