### PR TITLE
Fix typo in modules config and restrict to EPEL (#232)

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -65,11 +65,11 @@
     src: "/usr/share/nginx/modules/{{ item }}.conf"
     dest: "{{ nginx_conf_dir }}/modules-enabled/{{ item }}.conf"
   with_items: "{{ nginx_module_configs }}"
-  when: (item not in nginx_remove_modules) and (item not in nginx_disabled_modules)
   ignore_errors: "{{ ansible_check_mode }}"
   notify:
     - reload nginx
   when:
+    - (item not in nginx_remove_modules) and (item not in nginx_disabled_modules)
     - ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
     - nginx_install_epel_repo
 

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -62,11 +62,14 @@
 - name: Create links for modules-enabled
   file:
     state: link
-    src: "/urs/share/nginx/modules/{{ item }}.conf"
+    src: "/usr/share/nginx/modules/{{ item }}.conf"
     dest: "{{ nginx_conf_dir }}/modules-enabled/{{ item }}.conf"
   with_items: "{{ nginx_module_configs }}"
   when: (item not in nginx_remove_modules) and (item not in nginx_disabled_modules)
   ignore_errors: "{{ ansible_check_mode }}"
   notify:
     - reload nginx
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+  when:
+    - ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+    - nginx_install_epel_repo
+


### PR DESCRIPTION
This fixes a small typo and also restricts the configuring modules a little further so that it only applies when the EPEL based version of Nginx is installed (this is the default).