### PR TITLE
Extends support for configuring modules (#236)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,36 @@ nginx_amplify: true
 nginx_amplify_api_key: "your_api_key_goes_here"
 nginx_amplify_update_agent: true
 
-# Define modules (only for RHEL & CentOS).
-# available modules:.
+# Define modules to enable in configuration
+#
+# Nginx installed via EPEL and APT repos will also install some modules automatically.
+# For official Nginx repo use you will need to install module packages manually.
+#
+# When using with EPEL and APT repos, specify this section as a list of configuration
+# file names, minus the .conf file name extension.
+
+# When using the official Nginx repo, specify this section as list of module file
+# names, minus the .so file name extension.
+#
+# Available module config files in EPEL and APT repos:
+# (APT actually has several more, see https://wiki.debian.org/Nginx/)
 # - mod-http-geoip
 # - mod-http-image-filter
 # - mod-http-perl
 # - mod-http-xslt-filter
 # - mod-mail
 # - mod-stream
+#
+# Available module filenames in Official NGINX repo:
+# - ngx_http_geoip_module
+# - ngx_http_image_filter_module
+# - ngx_http_perl_module
+# - ngx_http_xslt_filter_module
+# - ngx_http_js_module
+#
+# Custom compiled modules are ok too if the .so file exists in same location as a packaged module would be:
+# - ngx_http_modsecurity_module
+#
 nginx_module_configs:
   - mod-http-geoip
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,6 +57,7 @@ nginx_disabled_sites: []
 nginx_module_configs: []
 nginx_remove_modules: []
 nginx_disabled_modules: []
+nginx_modules_location: /usr/lib64/nginx/modules # For this variable, a specific value for the OS can be applied in vars/{{ ansible_os_family }}.
 
 nginx_configs: {}
 nginx_snippets: {}

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -59,11 +59,23 @@
     - reload nginx
   when: nginx_stream_params or nginx_stream_configs
 
-- name: Create links for modules-enabled
+- name: Create configuration files in modules-available (only for nginx official repo or custom modules, Centos/RHEL/Debian/Ubuntu EPEL/APT repo packages have these config files already)
+  template:
+    src: module.conf.j2
+    dest: "{{ nginx_conf_dir }}/modules-available/{{ item }}.conf"
+  with_items: "{{ nginx_module_configs }}"
+  ignore_errors: "{{ ansible_check_mode }}"
+  notify:
+    - reload nginx
+  when:
+    - (item not in nginx_remove_modules) and (item not in nginx_disabled_modules)
+    - nginx_official_repo
+
+- name: Create links in modules-available to Centos/RHEL EPEL provided configuration files. Debian/Ubuntu APT provided packages already have these config files.
   file:
     state: link
     src: "/usr/share/nginx/modules/{{ item }}.conf"
-    dest: "{{ nginx_conf_dir }}/modules-enabled/{{ item }}.conf"
+    dest: "{{ nginx_conf_dir }}/modules-available/{{ item }}.conf"
   with_items: "{{ nginx_module_configs }}"
   ignore_errors: "{{ ansible_check_mode }}"
   notify:
@@ -71,5 +83,43 @@
   when:
     - (item not in nginx_remove_modules) and (item not in nginx_disabled_modules)
     - ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
-    - nginx_install_epel_repo
+    - not nginx_official_repo
+
+- name: Create links in our modules-available to Debian/Ubuntu APT provided config files.
+  file:
+    state: link
+    src: "/usr/share/nginx/modules-available/{{ item }}.conf"
+    dest: "{{ nginx_conf_dir }}/modules-available/{{ item }}.conf"
+  with_items: "{{ nginx_module_configs }}"
+  ignore_errors: "{{ ansible_check_mode }}"
+  notify:
+    - reload nginx
+  when:
+    - (item not in nginx_remove_modules) and (item not in nginx_disabled_modules)
+    - ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+    - not nginx_official_repo
+
+- name: Move out of the way any existing "50-" style links in modules-available, only for Debian/Ubuntu APT provided packages
+  command: "mv {{ nginx_conf_dir }}/modules-enabled/50-{{ item }}.conf {{ nginx_conf_dir }}/modules-enabled/50-{{ item }}.conf.renamedasnowmanaged"
+  args:
+    removes: "{{ nginx_conf_dir }}/modules-enabled/50-{{ item }}.conf"
+  with_items: "{{ nginx_module_configs }}"
+  ignore_errors: "{{ ansible_check_mode }}"
+  notify:
+    - reload nginx
+  when:
+    - (item not in nginx_remove_modules) and (item not in nginx_disabled_modules)
+    - ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+    - not nginx_official_repo
+
+- name: Create links in modules-enabled from modules-available
+  file:
+    state: link
+    src: "{{ nginx_conf_dir }}/modules-available/{{ item }}.conf"
+    dest: "{{ nginx_conf_dir }}/modules-enabled/{{ item }}.conf"
+  with_items: "{{ nginx_module_configs }}"
+  when: (item not in nginx_remove_modules) and (item not in nginx_disabled_modules)
+  ignore_errors: "{{ ansible_check_mode }}"
+  notify:
+    - reload nginx
 

--- a/templates/module.conf.j2
+++ b/templates/module.conf.j2
@@ -1,3 +1,3 @@
 #{{ ansible_managed }}
 
-load_module "modules/{{ item }}.so";
+load_module "{{ nginx_modules_location }}/{{ item }}.so";

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,3 +4,5 @@ nginx_user: www-data
 nginx_python_selinux_pkgs:
   - python-selinux
   - python-semanage
+
+nginx_modules_location: /usr/lib/nginx/modules

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,3 +2,6 @@
 nginx_python_selinux_pkgs:
   - libselinux-python
   - libsemanage-python
+
+nginx_modules_location: /usr/lib64/nginx/modules
+


### PR DESCRIPTION
Module configuration should now work for the following:

 Centos/RHEL with either EPEL or Official Nginx repo
 Debian/Ubuntu with either standard APT repo or Official Nginx repo

Please see issue #236 for further details.