### PR TITLE
configuration: allow templates for conf.d independent files

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -36,7 +36,7 @@
 
 - name: Create the configurations for independent config file
   template:
-    src: config.conf.j2
+    src: "{{ item.value.template | default('config.conf.j2') }}"
     dest: "{{ nginx_conf_dir }}/conf.d/{{ item.key }}.conf"
   with_dict: "{{ nginx_configs }}"
   notify:


### PR DESCRIPTION
similarly to `sites` configuration `stream` configuration, allow the usage of custom templates to define `conf.d/*.conf` files.