### PR TITLE
Download mime.types file if it's missing

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -1,4 +1,20 @@
 ---
+
+- name: Check if nginx mime.types file exists
+  stat:
+    path: "{{ nginx_conf_dir }}/mime.types"
+  register: nginx_mime_types_file
+  notify:
+    - reload nginx
+
+- name: Ensure mime.types file exists if it was missing
+  get_url:
+    url: https://raw.githubusercontent.com/nginx/nginx/master/conf/mime.types
+    dest: "{{ nginx_conf_dir }}/mime.types"
+  when: nginx_mime_types_file.stat.exists == False
+  notify:
+    - reload nginx
+  
 - name: Copy the nginx configuration file
   template:
     src: nginx.conf.j2
@@ -122,4 +138,3 @@
   ignore_errors: "{{ ansible_check_mode }}"
   notify:
     - reload nginx
-


### PR DESCRIPTION
## What does it do?

After I ran this role on debian buster I noticed `/etc/nginx/mime.types` was missing. I'm unsure why. This PR downloads it from nginx's github if it is missing. I did not see that anyone else has run into the problem but we can keep this here as an idea or possible solution if we discover many others have the problem.

Thanks for having a look.

## How to test

```sh
ansible-galaxy remove jdauphant.nginx
ansible-galaxy install 'git+https://github.com/youreadforme/ansible-role-nginx.git,missing-mime-types'
```

`./nginx-test.yml`

```yml
- name: nginx test
  hosts: all
  become: true
  roles:
    - role: ansible-role-nginx
```

`./Vagrant file`

```ruby
# -*- mode: ruby -*-
# vi: set ft=ruby :
Vagrant.configure("2") do |config|
  config.vm.hostname = "nginx-test"
  config.vm.box = "debian/buster64"
  config.vm.box_check_update = false
  config.vm.provider "virtualbox" do |vb|
    vb.name = "nginx-test"
    vb.gui = false
    vb.cpus = 1
    vb.memory = 512
  end
  config.vm.provision "ansible" do |ansible|
    ansible.playbook = "./nginx-test.yml"
    ansible.verbose = "vvvv"
  end
end
```

```sh
vagrant ssh -c 'cat /etc/nginx/mime.types'
```
If you have a better way I should test these I'm open to tips. Usually I'm just running the roles over and over on a VM like this.