### PR TITLE
Newer os compatiblity with os dependent vars

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
 - name: include OS dependent vars
   include_vars: "{{ item }}"
   with_first_found:
+    - "../vars/{{ ansible_os_family }}-{{ ansible_distribution_major_version }}" 
     - "../vars/{{ ansible_os_family }}.yml"
     - "../vars/empty.yml"
   when: nginx_load_default_vars

--- a/vars/Debian-12.yml
+++ b/vars/Debian-12.yml
@@ -1,0 +1,8 @@
+---
+nginx_user: www-data
+
+nginx_python_selinux_pkgs:
+  - python3-selinux
+  - python3-semanage
+
+nginx_modules_location: /usr/lib/nginx/modules


### PR DESCRIPTION
Added a functionality to the task in main.yml that includes the os dependent vars whereby you can speficie the os version of the vars that you want. The corresponding file(s) for that os version must be created in the vars folder. The compatibility with Debian12 was also created in the vars folder.